### PR TITLE
feat(shell): open-stl IPC reads file and returns ArrayBuffer

### DIFF
--- a/shared/ipc-contracts.ts
+++ b/shared/ipc-contracts.ts
@@ -11,10 +11,34 @@ export interface OpenStlRequest {
   multi?: boolean;
 }
 
-export interface OpenStlResponse {
-  canceled: boolean;
-  paths: string[];
-}
+/**
+ * Typed error codes surfaced from `file:open-stl`.
+ *
+ * Kept small and string-literal so the renderer can exhaustively switch on it
+ * to pick a localised message. When adding a new variant, update every
+ * consumer — the TS compiler will flag missing cases.
+ */
+export type OpenStlError = 'file-too-large' | 'read-failed';
+
+/**
+ * Discriminated-union return type for `file:open-stl`.
+ *
+ * Narrowing rules (critical — the renderer relies on these):
+ * - `result.canceled === true` → user closed the native dialog, no other
+ *   fields are present.
+ * - `result.canceled === false && 'error' in result` → the main process
+ *   selected a file but failed to honour the request (e.g. oversized).
+ * - `result.canceled === false && !('error' in result)` → success; `name`
+ *   (basename) and `buffer` (ArrayBuffer of file bytes) are guaranteed.
+ *
+ * The `buffer: ArrayBuffer` shape transfers across the Electron IPC boundary
+ * via structured clone — the receiver sees a fresh ArrayBuffer, not a
+ * SharedArrayBuffer or a Node Buffer.
+ */
+export type OpenStlResponse =
+  | { canceled: true }
+  | { canceled: false; name: string; buffer: ArrayBuffer }
+  | { canceled: false; error: OpenStlError };
 
 export interface SaveStlRequest {
   /**
@@ -64,3 +88,13 @@ export interface ApiBridge {
     request: SaveStlRequest,
   ) => Promise<IpcContracts['file:save-stl']['result']>;
 }
+
+/**
+ * Hard upper bound on STL file size accepted by `file:open-stl`, in bytes.
+ *
+ * Aligned with the security guidance in CLAUDE.md and the desktop-app-shell
+ * skill: "Reject files > 500 MB without explicit user override." Main-process
+ * code `stat`s the file before reading it to avoid allocating a half-gig
+ * buffer just to refuse it.
+ */
+export const OPEN_STL_MAX_BYTES = 500 * 1024 * 1024;

--- a/src/main/dialogs.ts
+++ b/src/main/dialogs.ts
@@ -2,7 +2,6 @@ import { dialog, type OpenDialogOptions, type SaveDialogOptions } from 'electron
 import { promises as fs } from 'node:fs';
 import type {
   OpenStlRequest,
-  OpenStlResponse,
   SaveStlRequest,
   SaveStlResponse,
 } from '../../shared/ipc-contracts';
@@ -28,9 +27,21 @@ declare global {
 
 const isTest = (): boolean => process.env['NODE_ENV'] === 'test';
 
+/**
+ * Raw-dialog result for the Open-STL flow.
+ *
+ * Kept deliberately close to Electron's native `OpenDialogReturnValue` shape
+ * so the ipc.ts handler — which layers file reads and size checks on top —
+ * can stay thin.
+ */
+export interface OpenStlDialogResult {
+  canceled: boolean;
+  filePaths: string[];
+}
+
 export async function showOpenStl(
   request: OpenStlRequest,
-): Promise<OpenStlResponse> {
+): Promise<OpenStlDialogResult> {
   const options: OpenDialogOptions = {
     properties: request.multi
       ? ['openFile', 'multiSelections']
@@ -40,11 +51,14 @@ export async function showOpenStl(
 
   if (isTest() && globalThis.__testDialogStub?.showOpenDialog) {
     const stubbed = await globalThis.__testDialogStub.showOpenDialog(options);
-    return { canceled: stubbed.canceled, paths: stubbed.filePaths ?? [] };
+    return {
+      canceled: stubbed.canceled,
+      filePaths: stubbed.filePaths ?? [],
+    };
   }
 
   const result = await dialog.showOpenDialog(options);
-  return { canceled: result.canceled, paths: result.filePaths };
+  return { canceled: result.canceled, filePaths: result.filePaths };
 }
 
 export async function showSaveStl(

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,8 +1,12 @@
 import { app, ipcMain } from 'electron';
-import type {
-  IpcContracts,
-  OpenStlRequest,
-  SaveStlRequest,
+import { promises as fs } from 'node:fs';
+import { basename } from 'node:path';
+import {
+  OPEN_STL_MAX_BYTES,
+  type IpcContracts,
+  type OpenStlRequest,
+  type OpenStlResponse,
+  type SaveStlRequest,
 } from '../../shared/ipc-contracts';
 import { showOpenStl, showSaveStl } from './dialogs';
 
@@ -25,7 +29,7 @@ export function registerIpcHandlers(): void {
       _event,
       request: OpenStlRequest,
     ): Promise<IpcContracts['file:open-stl']['result']> => {
-      return showOpenStl(request ?? {});
+      return handleOpenStl(request ?? {});
     },
   );
 
@@ -38,4 +42,69 @@ export function registerIpcHandlers(): void {
       return showSaveStl(request);
     },
   );
+}
+
+/**
+ * End-to-end Open-STL flow: native dialog → bounded file read → ArrayBuffer
+ * payload suitable for structured-clone transport to the renderer.
+ *
+ * Size policy: files larger than `OPEN_STL_MAX_BYTES` (500 MB) are rejected
+ * based on the `fs.stat` size BEFORE any bytes are read into memory. This
+ * prevents a malicious or broken file from forcing a half-gig allocation in
+ * the main process.
+ *
+ * Error handling: anything other than an over-sized file (permission
+ * denied, file disappeared between stat and read, etc.) surfaces as
+ * `{ canceled: false, error: 'read-failed' }`. The renderer picks the
+ * localised copy from the error code.
+ */
+async function handleOpenStl(
+  request: OpenStlRequest,
+): Promise<OpenStlResponse> {
+  const dialogResult = await showOpenStl(request);
+  if (dialogResult.canceled || dialogResult.filePaths.length === 0) {
+    return { canceled: true };
+  }
+
+  // v1 `file:open-stl` is single-select only — even when `multi: true` is
+  // passed, we surface the first path. Multi-select wiring is a later
+  // concern and belongs to a follow-up issue.
+  const path = dialogResult.filePaths[0];
+  if (typeof path !== 'string' || path.length === 0) {
+    return { canceled: true };
+  }
+
+  let size: number;
+  try {
+    const stats = await fs.stat(path);
+    size = stats.size;
+  } catch {
+    return { canceled: false, error: 'read-failed' };
+  }
+
+  if (size > OPEN_STL_MAX_BYTES) {
+    return { canceled: false, error: 'file-too-large' };
+  }
+
+  let fileBytes: Buffer;
+  try {
+    fileBytes = await fs.readFile(path);
+  } catch {
+    return { canceled: false, error: 'read-failed' };
+  }
+
+  // Produce a clean, standalone ArrayBuffer. Node's `Buffer` shares an
+  // underlying allocator-pool ArrayBuffer that can be larger than the file
+  // and may be typed as `ArrayBufferLike` (ArrayBuffer | SharedArrayBuffer).
+  // Allocate a fresh ArrayBuffer of exactly `byteLength` bytes and copy in —
+  // this both tightens the byte range and guarantees the renderer sees a
+  // plain ArrayBuffer via structured clone.
+  const buffer = new ArrayBuffer(fileBytes.byteLength);
+  new Uint8Array(buffer).set(fileBytes);
+
+  return {
+    canceled: false,
+    name: basename(path),
+    buffer,
+  };
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -8,6 +8,12 @@ import type {
 /**
  * The single, typed surface that renderer code can see. Every call must go
  * through `window.api.*`. Raw `ipcRenderer` is NOT exposed.
+ *
+ * ArrayBuffer roundtrip: Electron's `ipcRenderer.invoke` uses structured
+ * clone for payloads. `openStl` returns an `OpenStlResponse` whose success
+ * variant carries a plain `ArrayBuffer`; the main process allocates and
+ * transfers a standalone ArrayBuffer (see src/main/ipc.ts) so the renderer
+ * receives a clean, exact-sized instance here — no slicing needed.
  */
 const api: ApiBridge = {
   getVersion: () => ipcRenderer.invoke('app:get-version'),

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { readFileSync } from 'node:fs';
+import { readFileSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { launchApp } from './fixtures/app';
 
@@ -7,26 +7,124 @@ const pkg = JSON.parse(
   readFileSync(resolve(__dirname, '..', '..', 'package.json'), 'utf8'),
 ) as { version: string };
 
+const MINI_FIGURINE_PATH = resolve(
+  __dirname,
+  '..',
+  'fixtures',
+  'meshes',
+  'mini-figurine.stl',
+);
+
 test('smoke: Electron app launches and shows package version via IPC', async () => {
   const app = await launchApp();
   try {
-    const window = await app.firstWindow();
-    await window.waitForLoadState('domcontentloaded');
+    const page = await app.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
 
     // Title is set in index.html
-    await expect(window).toHaveTitle(/Silicone Mold App/);
+    await expect(page).toHaveTitle(/Silicone Mold App/);
 
     // The version is hydrated via IPC — wait until it is replaced from the
     // default 'v…' placeholder.
-    const versionLocator = window.locator('[data-testid="app-version"]');
+    const versionLocator = page.locator('[data-testid="app-version"]');
     await expect(versionLocator).toHaveText(`v${pkg.version}`, {
       timeout: 10_000,
     });
 
-    // The Open STL button exists but is disabled in this PR.
-    const openBtn = window.locator('[data-testid="open-stl-btn"]');
+    // The Open STL button exists but is disabled in this PR — renderer-side
+    // wiring ships in a follow-up issue.
+    const openBtn = page.locator('[data-testid="open-stl-btn"]');
     await expect(openBtn).toBeVisible();
     await expect(openBtn).toBeDisabled();
+  } finally {
+    await app.close();
+  }
+});
+
+test('smoke: file:open-stl returns ArrayBuffer matching fixture byteLength', async () => {
+  const app = await launchApp();
+  try {
+    const page = await app.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
+
+    // Stub the native Open dialog in the main process. `app.evaluate` runs
+    // in the Electron main process; `globalThis.__testDialogStub` is the
+    // escape hatch that src/main/dialogs.ts honours only when NODE_ENV=test.
+    await app.evaluate((_electron, fixturePath) => {
+      (
+        globalThis as unknown as {
+          __testDialogStub: {
+            showOpenDialog: () => Promise<{
+              canceled: boolean;
+              filePaths: string[];
+            }>;
+          };
+        }
+      ).__testDialogStub = {
+        showOpenDialog: () =>
+          Promise.resolve({ canceled: false, filePaths: [fixturePath] }),
+      };
+    }, MINI_FIGURINE_PATH);
+
+    // Drive the IPC call directly from the renderer — the button is still
+    // disabled in this PR, so we exercise `window.api.openStl` through
+    // `page.evaluate`. The returned ArrayBuffer is marshalled over the
+    // structured-clone IPC boundary; we only need its byteLength here.
+    const result = await page.evaluate(async () => {
+      const response = await window.api.openStl({});
+      if (response.canceled) return { canceled: true as const };
+      if ('error' in response) {
+        return { canceled: false as const, error: response.error };
+      }
+      return {
+        canceled: false as const,
+        name: response.name,
+        byteLength: response.buffer.byteLength,
+      };
+    });
+
+    const expectedSize = statSync(MINI_FIGURINE_PATH).size;
+    expect(result).toEqual({
+      canceled: false,
+      name: 'mini-figurine.stl',
+      byteLength: expectedSize,
+    });
+    // Sanity check against the committed fixture size. If this drifts the
+    // fixture was regenerated — update the constant deliberately.
+    expect(expectedSize).toBe(289984);
+  } finally {
+    await app.close();
+  }
+});
+
+test('smoke: file:open-stl returns cancel variant when user dismisses dialog', async () => {
+  const app = await launchApp();
+  try {
+    const page = await app.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
+
+    await app.evaluate(() => {
+      (
+        globalThis as unknown as {
+          __testDialogStub: {
+            showOpenDialog: () => Promise<{
+              canceled: boolean;
+              filePaths: string[];
+            }>;
+          };
+        }
+      ).__testDialogStub = {
+        showOpenDialog: () =>
+          Promise.resolve({ canceled: true, filePaths: [] }),
+      };
+    });
+
+    const result = await page.evaluate(async () => {
+      const response = await window.api.openStl({});
+      return response;
+    });
+
+    expect(result).toEqual({ canceled: true });
   } finally {
     await app.close();
   }


### PR DESCRIPTION
# Summary

Replaces the `file:open-stl` stub with the end-to-end open flow: native dialog → bounded file read → `ArrayBuffer` marshalled across the IPC boundary. Models the result as a discriminated union so the compiler narrows `!canceled && !error` to `{ name, buffer }`.

## Linked issue

Closes #15

## Acceptance criteria (from the issue)

- [x] `pnpm install --frozen-lockfile` clean
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm test:e2e` all green
- [x] Stubbed E2E open-flow passes — `buffer.byteLength === 289984` for the mini-figurine fixture
- [x] File-size limit (500 MB) enforced in `src/main/ipc.ts`; attempting a larger file returns a typed `"file-too-large"` error
- [x] Typed IPC contract in `shared/ipc-contracts.ts`: `openStl` returns a discriminated union with `canceled: true | false`
- [x] `window.api.openStl` callable from renderer returns the union, fully typed — `window.api.openStl()` inferred correctly in IDE
- [x] No renderer-side `fs` / `child_process` / `ipcRenderer` still (grep)
- [x] CSP meta unchanged
- [ ] CI green on required checks (will verify on PR)

## What I did

- **`shared/ipc-contracts.ts`**: replaced `OpenStlResponse` with a 3-variant discriminated union — `{ canceled: true } | { canceled: false; name: string; buffer: ArrayBuffer } | { canceled: false; error: OpenStlError }`. Added `OPEN_STL_MAX_BYTES = 500 * 1024 * 1024` constant and `OpenStlError = 'file-too-large' | 'read-failed'` string-literal union.
- **`src/main/dialogs.ts`**: narrowed `showOpenStl` to return just the raw dialog result (`{ canceled, filePaths: string[] }`). The ipc layer owns the file read and size check, so the dialog module stays small and stub-friendly.
- **`src/main/ipc.ts`**: new `handleOpenStl` function. Calls the dialog, `fs.stat`s the selected path BEFORE allocating bytes, rejects > 500 MB with `error: 'file-too-large'`, catches stat / read failures with `error: 'read-failed'`, and returns `{ canceled: false, name, buffer }` on success. Allocates a fresh `ArrayBuffer` of exactly `byteLength` bytes and copies the file data in — avoids Node's pooled-allocator padding and the `ArrayBufferLike` typing ambiguity across structured-clone IPC.
- **`src/preload/index.ts`**: unchanged wiring; added a doc comment calling out the ArrayBuffer roundtrip semantics for future readers.
- **`tests/e2e/smoke.spec.ts`**: added two cases — a stubbed success flow that asserts `byteLength === 289984` and `name === 'mini-figurine.stl'` via `page.evaluate(() => window.api.openStl(...))`, and a cancel flow that asserts `{ canceled: true }`. Renamed the Playwright `Page` local from `window` to `page` so the `window.api` inside `page.evaluate` resolves to the browser global (not the `Page` object).

## Test results

- [x] `pnpm lint` — green on changed files (`eslint src/main src/preload shared tests/e2e` passes; pre-existing noise from `.claude/worktrees/*/dist/` artifacts is local-only and gitignored)
- [x] `pnpm typecheck` — green
- [x] `pnpm test` — 63 passed, 1 skipped (no regressions)
- [x] `pnpm test:e2e` — 3 passed (existing smoke + new byteLength assertion + cancel variant)
- [x] New unit tests added for changed geometry / behaviour — n/a, this is IPC; E2E covers the critical buffer-over-IPC roundtrip
- [x] Canonical-SHA-256 STL snapshots updated if mesh output changed — n/a

## Screenshots / GIFs (required if UI-touching)

N/A — this PR does not touch `src/renderer/` or any UI. The Open STL button stays disabled (renderer wiring is issue B).

## QA sign-off

- [ ] `qa-engineer` reviewed and approved
- [ ] Visual regression diff reviewed (if present) — acceptable / intentional

## Checklist

- [x] Units: any new numbers are in mm internally — n/a (only bytes)
- [x] i18n: user-visible strings routed through `i18next`, no hardcoded English — n/a (no user-visible strings; error codes are machine-readable enum values for the renderer to localise)
- [x] Secrets: no new credentials, tokens, or private keys in the diff
- [x] New env vars documented in `.env.example` — none added
- [ ] `docs/status.md` updated if this PR completes a milestone or changes scope — deferred to lead; this PR is one of several in the Phase 3a wave
- [x] CLAUDE.md still accurate (no decisions that contradict it)

## Agent attribution

Primary author: `app-shell-dev` (Sonnet)
Reviewed by: `qa-engineer`