### PR TITLE
feat(ui): topbar with volume readout + mm/inches toggle (i18n)

### DIFF
--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -1,0 +1,14 @@
+{
+  "volume": {
+    "label": "Volume",
+    "none": "No master loaded"
+  },
+  "units": {
+    "mm": "mm",
+    "in": "in"
+  },
+  "topbar": {
+    "open": "Open STL",
+    "appName": "Silicone Mold App"
+  }
+}

--- a/src/renderer/i18n/index.ts
+++ b/src/renderer/i18n/index.ts
@@ -1,0 +1,93 @@
+// src/renderer/i18n/index.ts
+//
+// Minimal i18next bootstrap for the renderer.
+//
+// - English only at v1 (per CLAUDE.md: "English only ships at v1, but all
+//   user-visible strings go through i18n from day 1").
+// - Single namespace ("translation", i18next default).
+// - Synchronous init so callers can `t('key')` immediately at module load
+//   time — no hydration race in the DOM.
+// - Exposes `getUnitSystem()` / `setUnitSystem()` for the mm/inches toggle.
+//   Persisted to `localStorage.units`; defaults to `'mm'` (project constraint).
+//   Emits a `units-changed` CustomEvent on `document` so any component can
+//   re-render when the user flips the toggle.
+//
+// This file deliberately holds the unit state (a renderer-global concern)
+// rather than a separate store — the app is tiny and an extra abstraction
+// layer would be noise at this stage.
+
+import i18next from 'i18next';
+import en from './en.json';
+
+export type UnitSystem = 'mm' | 'in';
+
+const UNITS_STORAGE_KEY = 'units';
+const DEFAULT_UNITS: UnitSystem = 'mm';
+
+/**
+ * Initialise i18next with the English bundle. Synchronous — uses the
+ * `initImmediate: false` flag so `t()` is usable right after this call.
+ * Safe to call more than once; i18next no-ops subsequent init calls.
+ */
+export function initI18n(): void {
+  if (i18next.isInitialized) return;
+  void i18next.init({
+    lng: 'en',
+    fallbackLng: 'en',
+    defaultNS: 'translation',
+    ns: ['translation'],
+    resources: {
+      en: {
+        translation: en,
+      },
+    },
+    // Synchronous init — we ship a single bundled resource, no HTTP backend.
+    initImmediate: false,
+    interpolation: {
+      // We don't need HTML escaping for a string returned into textContent.
+      escapeValue: false,
+    },
+  });
+}
+
+/**
+ * Translation helper. Thin wrapper over `i18next.t` so call sites don't need
+ * to import i18next directly and we can swap the backing lib later without
+ * a widespread refactor.
+ */
+export function t(key: string): string {
+  if (!i18next.isInitialized) {
+    initI18n();
+  }
+  // i18next's `t()` returns string when called with a plain key + no options.
+  return i18next.t(key);
+}
+
+/**
+ * Read the persisted unit system from localStorage. Defaults to 'mm'.
+ * Any corrupt value falls back to the default — we never throw here since
+ * this runs during UI mount.
+ */
+export function getUnitSystem(): UnitSystem {
+  try {
+    const raw = localStorage.getItem(UNITS_STORAGE_KEY);
+    if (raw === 'mm' || raw === 'in') return raw;
+  } catch {
+    // localStorage may be disabled (private mode, tests). Fall through.
+  }
+  return DEFAULT_UNITS;
+}
+
+/**
+ * Persist the selected unit system and broadcast a `units-changed`
+ * CustomEvent on `document`. Listeners should prefer the event over polling.
+ */
+export function setUnitSystem(unit: UnitSystem): void {
+  try {
+    localStorage.setItem(UNITS_STORAGE_KEY, unit);
+  } catch {
+    // Swallow — the toggle still works for the current session.
+  }
+  const event = new CustomEvent<UnitSystem>('units-changed', { detail: unit });
+  document.dispatchEvent(event);
+}

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -39,31 +39,85 @@
         height: 100%;
         width: 100%;
       }
-      header {
+      header.topbar {
         flex: 0 0 var(--topbar-h);
-        display: flex;
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
         align-items: center;
-        justify-content: space-between;
         padding: 0 16px;
         border-bottom: 1px solid var(--border);
         gap: 12px;
+        background: var(--bg);
       }
-      header .left,
-      header .right {
+      .topbar__left,
+      .topbar__center,
+      .topbar__right {
         display: flex;
         align-items: center;
         gap: 12px;
       }
-      header h1 {
+      .topbar__left {
+        justify-content: flex-start;
+      }
+      .topbar__center {
+        justify-content: center;
+      }
+      .topbar__right {
+        justify-content: flex-end;
+      }
+      .topbar__app-name {
         font-size: 14px;
         font-weight: 600;
         margin: 0;
         letter-spacing: 0.01em;
       }
-      header .version {
+      .topbar__version {
         color: var(--muted);
         font-variant-numeric: tabular-nums;
         font-size: 12px;
+      }
+      .topbar__volume {
+        display: inline-flex;
+        align-items: baseline;
+        gap: 6px;
+        font-variant-numeric: tabular-nums;
+      }
+      .topbar__volume-label {
+        color: var(--muted);
+        font-size: 12px;
+      }
+      .topbar__volume-value {
+        color: var(--fg);
+        font-size: 13px;
+        min-width: 10ch;
+        text-align: right;
+      }
+      .units-toggle {
+        display: inline-flex;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        overflow: hidden;
+      }
+      .units-toggle button {
+        appearance: none;
+        background: transparent;
+        color: var(--muted);
+        border: none;
+        border-radius: 0;
+        padding: 4px 10px;
+        font: inherit;
+        font-size: 12px;
+        cursor: pointer;
+      }
+      .units-toggle button + button {
+        border-left: 1px solid var(--border);
+      }
+      .units-toggle button.is-active {
+        background: var(--accent);
+        color: #0b0d10;
+      }
+      .units-toggle button:hover:not(.is-active) {
+        color: var(--fg);
       }
       #viewport {
         flex: 1 1 auto;
@@ -93,16 +147,8 @@
   </head>
   <body>
     <div id="app">
-      <header>
-        <div class="left">
-          <h1>Silicone Mold App</h1>
-        </div>
-        <div class="right">
-          <button type="button" data-testid="open-stl-btn" disabled>
-            Open STL…
-          </button>
-          <span class="version" data-testid="app-version">v…</span>
-        </div>
+      <header class="topbar" data-testid="topbar">
+        <!-- Populated by src/renderer/ui/topbar.ts on DOMContentLoaded -->
       </header>
       <div id="viewport" data-testid="viewport"></div>
     </div>

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -1,17 +1,27 @@
 /**
  * Renderer entry point.
  *
- * Hydrates the version string via the typed IPC bridge and mounts the
- * Three.js viewport into `#viewport`. The `window.api` surface is declared
- * in ./types.d.ts (picked up via the tsconfig include).
+ * Boots i18n, mounts the topbar (owns the Open STL button + volume readout
+ * + mm/inches toggle), hydrates the version string via the typed IPC
+ * bridge, and mounts the Three.js viewport into `#viewport`.
+ *
+ * The `window.api` surface is declared in ./types.d.ts (picked up via the
+ * tsconfig include).
  *
  * No STL loading, no parting-plane widget, no mesh-bvh wiring — those land
- * in later PRs. This file is deliberately thin.
+ * in later PRs. The Open STL button is rendered but disabled in this PR;
+ * issue #16 wires it up.
  */
 
 import { mount } from './scene/viewport';
+import { initI18n } from './i18n';
+import { mountTopbar, type TopbarApi } from './ui/topbar';
+
+let topbar: TopbarApi | null = null;
 
 async function hydrateVersion(): Promise<void> {
+  // The topbar owns the `[data-testid="app-version"]` element now; keep
+  // the existing hydration behaviour so the E2E smoke test still passes.
   const el = document.querySelector<HTMLSpanElement>('[data-testid="app-version"]');
   if (!el) return;
   try {
@@ -20,6 +30,26 @@ async function hydrateVersion(): Promise<void> {
   } catch (err) {
     console.error('Failed to fetch app version', err);
     el.textContent = 'v?';
+  }
+}
+
+function mountUi(): void {
+  const header = document.querySelector<HTMLElement>('header[data-testid="topbar"]');
+  if (!header) {
+    console.error('Missing <header data-testid="topbar"> — renderer HTML is out of date.');
+    return;
+  }
+  topbar = mountTopbar(header);
+
+  // Expose on the test-hook surface so visual specs can drive the UI
+  // deterministically (set a known volume, flip units) without clicking.
+  if (process.env.NODE_ENV === 'test') {
+    const w = window as unknown as {
+      __testHooks?: Record<string, unknown>;
+    };
+    const hooks = w.__testHooks ?? {};
+    hooks['topbar'] = topbar;
+    w.__testHooks = hooks;
   }
 }
 
@@ -33,6 +63,8 @@ function mountViewport(): void {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  initI18n();
+  mountUi();
   mountViewport();
   void hydrateVersion();
 });

--- a/src/renderer/ui/formatters.ts
+++ b/src/renderer/ui/formatters.ts
@@ -1,0 +1,71 @@
+// src/renderer/ui/formatters.ts
+//
+// Pure, side-effect-free formatters for user-visible numeric values.
+//
+// IMPORTANT: everything here is deterministic against the `en-US` locale.
+// Per CLAUDE.md, internal units are mm throughout and inches is a *display*
+// conversion — so both inputs to `formatVolume` are mm³, and we convert to
+// in³ only for the inch output branch.
+//
+// Locale / grouping notes (pinned for tests and PR review):
+//   - `Intl.NumberFormat('en-US')` groups thousands with a comma (U+002C),
+//     e.g. 127 451.6 → "127,452" (rounded, maximumFractionDigits=0).
+//   - The issue body spelled sample outputs with spaces ("12 345 mm³"),
+//     which is how some locales (fr, fi, etc.) group. We use en-US comma
+//     grouping because that is the locale ADR-003 pins for tests, and the
+//     issue explicitly says "locale-appropriate US grouping — document if
+//     different". The unit-tests under `tests/renderer/formatters.test.ts`
+//     assert the comma form.
+//
+//   Conversion constant: 1 in = 25.4 mm → 1 in³ = 25.4^3 mm³ = 16 387.064 mm³.
+
+import { t } from '../i18n';
+
+export type UnitSystem = 'mm' | 'in';
+
+/** mm³ per in³. Pinned so the conversion is trivially auditable. */
+const MM3_PER_IN3 = 25.4 ** 3; // 16387.064
+
+/**
+ * en-US integer formatter for mm³. Thousands grouped with comma, no decimals.
+ * Rounds half-away-from-zero per `Intl.NumberFormat`'s default rounding mode
+ * in V8 (which implements the ECMA-402 `"halfExpand"` default).
+ */
+const MM3_FORMATTER = new Intl.NumberFormat('en-US', {
+  useGrouping: true,
+  maximumFractionDigits: 0,
+  minimumFractionDigits: 0,
+});
+
+/**
+ * en-US decimal formatter for in³. 3 decimal places, no grouping (values
+ * below 10 000 in³ never need grouping; above that the user has bigger
+ * issues than a comma).
+ */
+const IN3_FORMATTER = new Intl.NumberFormat('en-US', {
+  useGrouping: true,
+  maximumFractionDigits: 3,
+  minimumFractionDigits: 3,
+});
+
+/**
+ * Format a volume for display in the topbar.
+ *
+ * @param mm3  Volume in mm³, or `null` for the "no master loaded" state.
+ * @param unit The unit system to render — 'mm' → "X mm³", 'in' → "Y in³".
+ *
+ * @returns    Human-readable, locale-formatted string. Never throws.
+ */
+export function formatVolume(mm3: number | null, unit: UnitSystem): string {
+  if (mm3 === null || !Number.isFinite(mm3)) {
+    return t('volume.none');
+  }
+
+  if (unit === 'in') {
+    const in3 = mm3 / MM3_PER_IN3;
+    return `${IN3_FORMATTER.format(in3)} in\u00B3`;
+  }
+
+  // Default / mm branch.
+  return `${MM3_FORMATTER.format(mm3)} mm\u00B3`;
+}

--- a/src/renderer/ui/topbar.ts
+++ b/src/renderer/ui/topbar.ts
@@ -1,0 +1,145 @@
+// src/renderer/ui/topbar.ts
+//
+// Plain-DOM topbar component. Renders:
+//
+//   [ App name + version ]  [ Open STL (disabled) ]  [ Volume: ... ]  [ mm | in ]
+//
+// The "Open STL" button is intentionally disabled — issue #16 will enable it
+// in a follow-up PR. A disabled-state E2E smoke test depends on this.
+//
+// Exposes a small imperative API:
+//   - `setVolume(mm3)` — called later by the STL-loaded callback.
+//   - `setUnits(u)`    — programmatic override (keeps toggle + formatter in sync).
+//   - `getUnits()`     — read the active unit system.
+//
+// No framework; the component lifetime is the window lifetime.
+
+import { t, getUnitSystem, type UnitSystem } from '../i18n';
+import { formatVolume } from './formatters';
+import { mountUnitsToggle, type UnitsToggleApi } from './unitsToggle';
+
+export interface TopbarApi {
+  /** Set the master-mesh volume in mm³. Pass `null` to show the empty state. */
+  setVolume(mm3: number | null): void;
+  /** Programmatically flip the unit system. Mirrors the toggle buttons. */
+  setUnits(unit: UnitSystem): void;
+  /** Read current unit system. */
+  getUnits(): UnitSystem;
+}
+
+interface TopbarOptions {
+  /**
+   * Optional version string (e.g. "0.0.0"). Rendered as a muted suffix next
+   * to the app name. If omitted, the caller can set it later by mutating
+   * the `[data-testid="app-version"]` element directly — which is how
+   * `main.ts` currently hydrates it asynchronously via IPC.
+   */
+  version?: string;
+}
+
+/**
+ * Mount the topbar into `container`, replacing any existing children.
+ * The container is typically the `<header>` element already present in
+ * `index.html` — we want to preserve the body/viewport layout.
+ */
+export function mountTopbar(
+  container: HTMLElement,
+  options: TopbarOptions = {},
+): TopbarApi {
+  container.textContent = '';
+  container.classList.add('topbar');
+
+  // ---- Left: app name + version --------------------------------------------
+  const left = document.createElement('div');
+  left.className = 'topbar__left';
+
+  const appName = document.createElement('h1');
+  appName.className = 'topbar__app-name';
+  appName.textContent = t('topbar.appName');
+  left.appendChild(appName);
+
+  const version = document.createElement('span');
+  version.className = 'topbar__version';
+  version.dataset['testid'] = 'app-version';
+  version.textContent = options.version ? `v${options.version}` : 'v…';
+  left.appendChild(version);
+
+  // ---- Center: Open STL (still disabled in this PR) ------------------------
+  const center = document.createElement('div');
+  center.className = 'topbar__center';
+
+  const openBtn = document.createElement('button');
+  openBtn.type = 'button';
+  openBtn.className = 'topbar__open-btn';
+  openBtn.dataset['testid'] = 'open-stl-btn';
+  openBtn.textContent = t('topbar.open');
+  // DO NOT enable this — issue #16 owns enabling it. The E2E smoke test
+  // asserts `toBeDisabled()`. Flipping it here will break CI.
+  openBtn.disabled = true;
+  center.appendChild(openBtn);
+
+  // ---- Right: volume readout + units toggle --------------------------------
+  const right = document.createElement('div');
+  right.className = 'topbar__right';
+
+  const volumeWrap = document.createElement('div');
+  volumeWrap.className = 'topbar__volume';
+  volumeWrap.dataset['testid'] = 'volume-readout';
+
+  const volumeLabel = document.createElement('span');
+  volumeLabel.className = 'topbar__volume-label';
+  volumeLabel.textContent = t('volume.label') + ':';
+  volumeWrap.appendChild(volumeLabel);
+
+  const volumeValue = document.createElement('span');
+  volumeValue.className = 'topbar__volume-value';
+  volumeValue.dataset['testid'] = 'volume-value';
+  volumeWrap.appendChild(volumeValue);
+
+  right.appendChild(volumeWrap);
+
+  const togglePanel = document.createElement('div');
+  togglePanel.className = 'topbar__units';
+  right.appendChild(togglePanel);
+
+  container.appendChild(left);
+  container.appendChild(center);
+  container.appendChild(right);
+
+  // ---- State + rendering ---------------------------------------------------
+  let currentVolume: number | null = null;
+  let currentUnits: UnitSystem = getUnitSystem();
+
+  const toggle: UnitsToggleApi = mountUnitsToggle(togglePanel);
+
+  function renderVolume(): void {
+    volumeValue.textContent = formatVolume(currentVolume, currentUnits);
+  }
+
+  // Listen for unit changes fired by the toggle (or by another component)
+  // and re-render the volume so the unit label stays in sync.
+  document.addEventListener('units-changed', (ev) => {
+    const detail = (ev as CustomEvent<UnitSystem>).detail;
+    if (detail === 'mm' || detail === 'in') {
+      currentUnits = detail;
+      renderVolume();
+    }
+  });
+
+  renderVolume();
+
+  return {
+    setVolume(mm3: number | null): void {
+      currentVolume = mm3;
+      renderVolume();
+    },
+    setUnits(unit: UnitSystem): void {
+      toggle.setUnits(unit);
+      currentUnits = unit;
+      renderVolume();
+    },
+    getUnits(): UnitSystem {
+      return currentUnits;
+    },
+  };
+}

--- a/src/renderer/ui/unitsToggle.ts
+++ b/src/renderer/ui/unitsToggle.ts
@@ -1,0 +1,91 @@
+// src/renderer/ui/unitsToggle.ts
+//
+// Tiny internal helper used by the topbar. Renders a two-segment button
+// group ("mm" | "in"), persists the selection through the shared i18n
+// module (which owns `localStorage.units` + the `units-changed` event).
+//
+// Kept separate from `topbar.ts` so it can be unit-tested or reused
+// without dragging in the full topbar layout.
+
+import { getUnitSystem, setUnitSystem, t, type UnitSystem } from '../i18n';
+
+export interface UnitsToggleApi {
+  /** Set the active unit (also persists + broadcasts the event). */
+  setUnits(unit: UnitSystem): void;
+  /** Current unit. */
+  getUnits(): UnitSystem;
+  /** Remove DOM listeners if the toggle is unmounted (unused today, tidy). */
+  destroy(): void;
+}
+
+/**
+ * Mount a segmented mm/inches toggle into `host`. Returns an API the
+ * parent topbar can use to read or override the selection.
+ */
+export function mountUnitsToggle(host: HTMLElement): UnitsToggleApi {
+  const root = document.createElement('div');
+  root.className = 'units-toggle';
+  root.setAttribute('role', 'group');
+  root.setAttribute('aria-label', t('units.mm') + ' / ' + t('units.in'));
+  root.dataset['testid'] = 'units-toggle';
+
+  const mmBtn = document.createElement('button');
+  mmBtn.type = 'button';
+  mmBtn.textContent = t('units.mm');
+  mmBtn.dataset['testid'] = 'units-toggle-mm';
+  mmBtn.dataset['unit'] = 'mm';
+
+  const inBtn = document.createElement('button');
+  inBtn.type = 'button';
+  inBtn.textContent = t('units.in');
+  inBtn.dataset['testid'] = 'units-toggle-in';
+  inBtn.dataset['unit'] = 'in';
+
+  root.appendChild(mmBtn);
+  root.appendChild(inBtn);
+  host.appendChild(root);
+
+  let current: UnitSystem = getUnitSystem();
+
+  function sync(): void {
+    mmBtn.setAttribute('aria-pressed', current === 'mm' ? 'true' : 'false');
+    inBtn.setAttribute('aria-pressed', current === 'in' ? 'true' : 'false');
+    mmBtn.classList.toggle('is-active', current === 'mm');
+    inBtn.classList.toggle('is-active', current === 'in');
+  }
+
+  function choose(unit: UnitSystem): void {
+    if (unit === current) return;
+    current = unit;
+    setUnitSystem(unit);
+    sync();
+  }
+
+  mmBtn.addEventListener('click', () => choose('mm'));
+  inBtn.addEventListener('click', () => choose('in'));
+
+  // Listen for external changes (e.g. tests or other components).
+  const onExternal = (ev: Event): void => {
+    const detail = (ev as CustomEvent<UnitSystem>).detail;
+    if ((detail === 'mm' || detail === 'in') && detail !== current) {
+      current = detail;
+      sync();
+    }
+  };
+  document.addEventListener('units-changed', onExternal);
+
+  sync();
+
+  return {
+    setUnits(unit: UnitSystem): void {
+      choose(unit);
+    },
+    getUnits(): UnitSystem {
+      return current;
+    },
+    destroy(): void {
+      document.removeEventListener('units-changed', onExternal);
+      root.remove();
+    },
+  };
+}

--- a/tests/renderer/formatters.test.ts
+++ b/tests/renderer/formatters.test.ts
@@ -1,0 +1,65 @@
+// tests/renderer/formatters.test.ts
+//
+// Unit tests for the topbar volume formatter. These pin the exact output
+// strings so any change in rounding or locale grouping is caught in CI.
+//
+// Locale policy (mirrors the comment block at the top of
+// `src/renderer/ui/formatters.ts`):
+//
+//   - `Intl.NumberFormat('en-US')` is the single locale used for this
+//     formatter. Thousands separator is the comma (U+002C).
+//   - The issue #17 body suggested "12 345 mm³" with a space as a sample;
+//     we use comma grouping per the issue's "locale-appropriate US
+//     grouping — document if different" escape hatch. Documented here and
+//     in the PR body.
+//   - mm: integer (maximumFractionDigits = 0).
+//   - in: three decimals (minimum = maximum = 3 fraction digits).
+//   - Conversion: 1 in³ = 25.4^3 mm³ = 16 387.064 mm³.
+
+import { describe, expect, test } from 'vitest';
+
+import { formatVolume } from '@/renderer/ui/formatters';
+
+describe('formatVolume', () => {
+  test('null → localised "No master loaded"', () => {
+    expect(formatVolume(null, 'mm')).toBe('No master loaded');
+    expect(formatVolume(null, 'in')).toBe('No master loaded');
+  });
+
+  test('NaN / Infinity → localised "No master loaded"', () => {
+    expect(formatVolume(Number.NaN, 'mm')).toBe('No master loaded');
+    expect(formatVolume(Number.POSITIVE_INFINITY, 'mm')).toBe('No master loaded');
+  });
+
+  test('1 mm³ → "1 mm³"', () => {
+    expect(formatVolume(1, 'mm')).toBe('1 mm\u00B3');
+  });
+
+  test('12345 mm³ → "12,345 mm³" (en-US grouping)', () => {
+    // en-US uses U+002C (comma). See header comment for the rationale.
+    expect(formatVolume(12345, 'mm')).toBe('12,345 mm\u00B3');
+  });
+
+  test('127451.6 mm³ → "127,452 mm³" (rounded to nearest int)', () => {
+    expect(formatVolume(127451.6, 'mm')).toBe('127,452 mm\u00B3');
+  });
+
+  test('1 mm³ → inches is ≈ 6.1e-5 in³ → "0.000 in³"', () => {
+    expect(formatVolume(1, 'in')).toBe('0.000 in\u00B3');
+  });
+
+  test('16387 mm³ → inches is ≈ 1 in³ → "1.000 in³"', () => {
+    // 16 387 mm³ / 16 387.064 mm³/in³ ≈ 0.99999609… → rounds to "1.000"
+    expect(formatVolume(16387, 'in')).toBe('1.000 in\u00B3');
+  });
+
+  test('exact 16387.064 mm³ → "1.000 in³"', () => {
+    expect(formatVolume(16387.064, 'in')).toBe('1.000 in\u00B3');
+  });
+
+  test('negative volume renders without crashing (defensive)', () => {
+    // Volumes should never be negative in practice, but we don't want a
+    // runtime crash in the UI if a caller passes a signed value.
+    expect(formatVolume(-1, 'mm')).toBe('-1 mm\u00B3');
+  });
+});

--- a/tests/visual/topbar-units.spec.ts
+++ b/tests/visual/topbar-units.spec.ts
@@ -1,0 +1,122 @@
+// tests/visual/topbar-units.spec.ts
+//
+// Visual regression for the topbar UI. Captures four states:
+//
+//   1. mm mode, no master loaded (placeholder state).
+//   2. mm mode, with a known volume (mini-figurine's 127 451.6 mm³).
+//   3. in mode, no master loaded.
+//   4. in mode, with the same volume.
+//
+// Uses `window.__testHooks.topbar` (exposed by `main.ts` when the build
+// runs with `NODE_ENV=test`) to drive the state deterministically rather
+// than clicking through the UI.
+//
+// The capture area is clipped to the topbar row so downstream viewport
+// rendering (which has its own visual spec in `scene-empty-axes.spec.ts`)
+// does not pollute the diff.
+
+import { expect, test, type Page } from '@playwright/test';
+
+const RENDERER_URL = 'http://localhost:5174/?test=1';
+const TOPBAR_CLIP = { x: 0, y: 0, width: 1280, height: 48 } as const;
+
+interface TopbarHook {
+  setVolume(mm3: number | null): void;
+  setUnits(unit: 'mm' | 'in'): void;
+  getUnits(): 'mm' | 'in';
+}
+
+/**
+ * Stub `window.api` before navigation and clear any persisted units so
+ * each test starts from the default (mm). Then wait for the topbar API
+ * to be installed on `__testHooks`.
+ */
+async function openRenderer(page: Page): Promise<void> {
+  await page.clock.install({ time: new Date('2026-04-18T00:00:00Z') });
+  await page.addInitScript(() => {
+    (window as unknown as { api: Record<string, unknown> }).api = {
+      getVersion: () => Promise.resolve('0.0.0'),
+      openStl: () =>
+        Promise.resolve({ canceled: true, paths: [] as string[] }),
+      saveStl: () => Promise.resolve({ canceled: true }),
+    };
+    try {
+      window.localStorage.removeItem('units');
+    } catch {
+      /* ignore */
+    }
+  });
+  await page.goto(RENDERER_URL);
+  await page.waitForFunction(
+    () =>
+      !!(
+        window as unknown as { __testHooks?: { topbar?: TopbarHook } }
+      ).__testHooks?.topbar,
+    undefined,
+    { timeout: 10_000 },
+  );
+  // One RAF tick so the version IPC stub settles and the topbar fully paints.
+  await page.clock.runFor(50);
+}
+
+test.describe('visual — topbar units', () => {
+  test('mm mode, no master loaded', async ({ page }) => {
+    await openRenderer(page);
+    await page.evaluate(() => {
+      const t = (
+        window as unknown as { __testHooks: { topbar: TopbarHook } }
+      ).__testHooks.topbar;
+      t.setUnits('mm');
+      t.setVolume(null);
+    });
+    await page.clock.runFor(50);
+    await expect(page).toHaveScreenshot('topbar-mm-empty.png', {
+      clip: TOPBAR_CLIP,
+    });
+  });
+
+  test('mm mode, mini-figurine volume', async ({ page }) => {
+    await openRenderer(page);
+    await page.evaluate(() => {
+      const t = (
+        window as unknown as { __testHooks: { topbar: TopbarHook } }
+      ).__testHooks.topbar;
+      t.setUnits('mm');
+      t.setVolume(127451.6);
+    });
+    await page.clock.runFor(50);
+    await expect(page).toHaveScreenshot('topbar-mm-mini-figurine.png', {
+      clip: TOPBAR_CLIP,
+    });
+  });
+
+  test('inches mode, no master loaded', async ({ page }) => {
+    await openRenderer(page);
+    await page.evaluate(() => {
+      const t = (
+        window as unknown as { __testHooks: { topbar: TopbarHook } }
+      ).__testHooks.topbar;
+      t.setUnits('in');
+      t.setVolume(null);
+    });
+    await page.clock.runFor(50);
+    await expect(page).toHaveScreenshot('topbar-in-empty.png', {
+      clip: TOPBAR_CLIP,
+    });
+  });
+
+  test('inches mode, mini-figurine volume', async ({ page }) => {
+    await openRenderer(page);
+    await page.evaluate(() => {
+      const t = (
+        window as unknown as { __testHooks: { topbar: TopbarHook } }
+      ).__testHooks.topbar;
+      t.setUnits('in');
+      t.setVolume(127451.6);
+    });
+    await page.clock.runFor(50);
+    await expect(page).toHaveScreenshot('topbar-in-mini-figurine.png', {
+      clip: TOPBAR_CLIP,
+    });
+  });
+});


### PR DESCRIPTION
# Summary

Phase-3a topbar component — app name + version on the left, the existing Open STL button (still disabled; #16 enables it) in the centre, a volume readout on the right, and a mm/inches toggle at the far right. Minimal `i18next` bootstrap so no hardcoded user-visible English lives in the DOM, plus a pure `formatVolume(mm3, unit)` formatter with unit-tested exact output strings and a four-state visual-regression spec.

## Linked issue

Closes #17

## Acceptance criteria (from the issue)

- [x] `pnpm install --frozen-lockfile` clean — new dep `i18next` was already in `package.json`; no other deps added
- [x] `pnpm lint && pnpm typecheck && pnpm test` all green locally (72 tests passing)
- [x] `pnpm test:e2e` green locally — smoke test still asserts Open STL visible + disabled
- [x] `pnpm test:visual` — new `topbar-units.spec.ts` passes locally in all four states (Linux-CI goldens will be generated by CI on merge, same policy as `scene-empty-axes.spec.ts`)
- [x] Topbar renders in both mm and inches modes; toggling updates the displayed unit and re-formats the placeholder (visual spec covers both)
- [x] `formatVolume(null, u)` returns the localised "No master loaded" string
- [x] `formatVolume(16387, 'in')` rounds to `"1.000 in³"`
- [x] `formatVolume(127451.6, 'mm')` is `"127,452 mm³"` — **note:** the issue body sampled `"127 452 mm³"` with a space, which is how some European locales group. Per the issue's escape hatch ("locale-appropriate US grouping — document if different"), this PR pins en-US locale, which uses a comma (U+002C). Rationale + pinning comments live at the top of `src/renderer/ui/formatters.ts` and inside the unit-test file.
- [x] Units persist across page reload (localStorage `units`, default `mm`)
- [x] Grep confirms no hardcoded English in the renderer DOM — all user text via `t(key)`
- [x] Open STL button remains present in the topbar **and remains disabled** — issue #16 enables it
- [x] CSP meta unchanged (verified in diff)
- [ ] CI green on required checks (waiting on CI run)

## What I did

- `src/renderer/i18n/en.json` — seed bundle with `volume.label`, `volume.none`, `units.mm`, `units.in`, `topbar.open`, `topbar.appName`.
- `src/renderer/i18n/index.ts` — synchronous `i18next.init`, plus `t(key)`, `getUnitSystem()`, `setUnitSystem(u)`. `setUnitSystem` persists to `localStorage.units` and broadcasts a `units-changed` `CustomEvent` on `document`.
- `src/renderer/ui/formatters.ts` — pure `formatVolume(mm3, unit)` using `Intl.NumberFormat('en-US')`. Comment block documents the en-US locale choice, the `16387.064 mm³/in³` conversion constant, and why we comma-group instead of space-group.
- `src/renderer/ui/unitsToggle.ts` — tiny segmented-button helper (mm / in) with proper `aria-pressed` state, listens for external `units-changed` events so programmatic changes stay in sync.
- `src/renderer/ui/topbar.ts` — top-level DOM component. Exports `mountTopbar(container, { version? }): { setVolume, setUnits, getUnits }`. Renders the disabled Open STL button, the volume readout, and the units toggle.
- `src/renderer/main.ts` — now boots i18n then mounts `topbar` into the existing `<header data-testid="topbar">`. Version hydration still targets `[data-testid="app-version"]` (now a child of the topbar), so the E2E smoke test passes without modification. Exposes `__testHooks.topbar` only when `NODE_ENV === 'test'`.
- `src/renderer/index.html` — replaced the ad-hoc header contents with an empty `<header data-testid="topbar">` the component populates. CSS extended with `.topbar__*` and `.units-toggle` classes. CSP meta untouched.
- `tests/renderer/formatters.test.ts` — 9 tests pinning exact output strings, including `null` / `NaN` / `Infinity` fallbacks.
- `tests/visual/topbar-units.spec.ts` — 4 visual-regression tests clipped to the 48 px topbar row.

## Test results

- [x] `pnpm lint` — green
- [x] `pnpm typecheck` — green
- [x] `pnpm test` — green, 72 tests (1 pre-existing skip), coverage unchanged on `src/geometry/**`
- [x] `pnpm test:e2e` — green on windows
- [x] `pnpm test:visual` — 4 new topbar specs passing locally under `tests/__screenshots__/win32-ci/` (gitignored; Linux-CI is the source of truth)
- [x] No new unit tests needed for geometry (no geometry changes)
- [x] No STL snapshot churn

## Screenshots

Topbar states (captured via Playwright `toHaveScreenshot`, 1280×48 clip):

- `topbar-mm-empty.png` — mm active, "Volume: No master loaded"
- `topbar-mm-mini-figurine.png` — mm active, "Volume: 127,452 mm³"
- `topbar-in-empty.png` — in active, "Volume: No master loaded"
- `topbar-in-mini-figurine.png` — in active, "Volume: 7.778 in³"

(Local PNGs at `tests/__screenshots__/win32-ci/visual/topbar-units.spec.ts-snapshots/` are gitignored — Linux CI generates the authoritative goldens.)

## QA sign-off

- [ ] `qa-engineer` reviewed and approved
- [ ] Visual-regression diff reviewed (if present) — acceptable / intentional (this PR *introduces* the goldens)

## Checklist

- [x] Units: mm is internal; inches is a display-layer conversion in `formatVolume`
- [x] i18n: all user-visible strings via `t(key)`; grep in the diff confirms no hardcoded English in renderer DOM
- [x] Secrets: none
- [x] New env vars: none
- [ ] `docs/status.md` update left to the lead at merge time (this PR alone doesn't close a milestone)
- [x] CLAUDE.md still accurate

## Agent attribution

Primary author: `frontend-dev`
Reviewed by: `qa-engineer`