### PR TITLE
fix(build): serve manifold-3d WASM correctly in vite dev

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,6 +47,19 @@ export default defineConfig(({ mode }) => ({
     port: 5173,
     strictPort: true,
   },
+  // `manifold-3d` ships an Emscripten JS loader that locates its sidecar
+  // `.wasm` via a relative URL. Vite's default pre-bundling rewrites the
+  // JS into `node_modules/.vite/deps/` but does NOT surface the sibling
+  // `.wasm` to the dev server, so `WebAssembly.instantiate` receives the
+  // SPA fallback HTML and fails with `expected magic word ... found 3c 21 64 6f`.
+  // Excluding manifold-3d from pre-bundling preserves the upstream
+  // relative-URL resolution. `assetsInclude` makes Vite serve .wasm with
+  // the correct MIME. Production `vite build` is unaffected (Rollup
+  // handles the WASM asset).
+  optimizeDeps: {
+    exclude: ['manifold-3d'],
+  },
+  assetsInclude: ['**/*.wasm'],
   plugins: [
     electron({
       main: {


### PR DESCRIPTION
## Summary

Vite dev pre-bundling broke manifold-3d WASM loading. Result: pnpm dev could open the file dialog but the STL never rendered — manifold-3d's WebAssembly.instantiate got HTML back from Vite (`<!do`...) instead of the WASM magic word. Discovered during local user testing (lead ran pnpm dev + tried to load mini-figurine).

Fix is a 13-line vite.config.ts change: optimizeDeps.exclude=['manifold-3d'] + assetsInclude=['**/*.wasm']. Preserves upstream relative-URL resolution; no effect on production vite build (Rollup already handles the asset).

## Test

- Verified locally: pnpm dev, click Open STL, pick mini-figurine.stl, mesh renders + volume displayed. ✓
- CI e2e/visual unaffected (those run the built bundle, not the dev server).

## Linked issue

Surfaced during manual verification — no prior issue. Lead-authored bug fix.

## Agent attribution

Primary author: lead
Self-merge per autonomy policy (bug fix; required CI checks green).