### PR TITLE
feat(ui): mold parameter form in right sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "electron-updater": "^6.3.0",
     "eslint": "^9.16.0",
     "globals": "^17.5.0",
+    "happy-dom": "^20.9.0",
     "prettier": "^3.4.0",
     "typescript": "^5.6.0",
     "typescript-eslint": "^8.58.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
         version: 0.169.0
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(happy-dom@20.9.0)(jiti@2.6.1))
       electron:
         specifier: ^41.2.1
         version: 41.2.1
@@ -51,6 +51,9 @@ importers:
       globals:
         specifier: ^17.5.0
         version: 17.5.0
+      happy-dom:
+        specifier: ^20.9.0
+        version: 20.9.0
       prettier:
         specifier: ^3.4.0
         version: 3.8.3
@@ -68,7 +71,7 @@ importers:
         version: 0.29.1
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(happy-dom@20.9.0)(jiti@2.6.1)
 
 packages:
 
@@ -789,6 +792,12 @@ packages:
   '@types/webxr@0.5.24':
     resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
@@ -1259,6 +1268,10 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -1523,6 +1536,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -2470,6 +2487,10 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2499,6 +2520,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
@@ -3140,6 +3173,12 @@ snapshots:
 
   '@types/webxr@0.5.24': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.17
+
   '@types/yauzl@2.10.3':
     dependencies:
       '@types/node': 22.19.17
@@ -3236,7 +3275,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.2
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(happy-dom@20.9.0)(jiti@2.6.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -3251,7 +3290,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(happy-dom@20.9.0)(jiti@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3764,6 +3803,8 @@ snapshots:
     dependencies:
       once: 1.4.0
 
+  entities@7.0.1: {}
+
   env-paths@2.2.1: {}
 
   err-code@2.0.3: {}
@@ -4102,6 +4143,18 @@ snapshots:
       responselike: 2.0.1
 
   graceful-fs@4.2.11: {}
+
+  happy-dom@20.9.0:
+    dependencies:
+      '@types/node': 22.19.17
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0: {}
 
@@ -5020,7 +5073,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.6.1):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(happy-dom@20.9.0)(jiti@2.6.1):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -5048,6 +5101,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.13
       '@types/node': 22.19.17
+      happy-dom: 20.9.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -5065,6 +5119,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  whatwg-mimetype@3.0.0: {}
 
   which@2.0.2:
     dependencies:
@@ -5094,6 +5150,8 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
+
+  ws@8.20.0: {}
 
   xmlbuilder@15.1.1: {}
 

--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -5,10 +5,29 @@
   },
   "units": {
     "mm": "mm",
-    "in": "in"
+    "in": "in",
+    "deg": "°"
   },
   "topbar": {
     "open": "Open STL",
     "appName": "Silicone Mold App"
+  },
+  "parameters": {
+    "title": "Mold parameters",
+    "wall": "Wall thickness",
+    "base": "Base thickness",
+    "sideCount": "Side count",
+    "sprue": "Sprue diameter",
+    "vent": "Vent diameter",
+    "ventCount": "Vent count",
+    "keyStyle": "Registration keys",
+    "keyStyleOptions": {
+      "asymmetric-hemi": "Asymmetric hemispheres",
+      "cone": "Cone",
+      "keyhole": "Keyhole"
+    },
+    "draft": "Draft angle",
+    "reset": "Reset to defaults",
+    "invalid": "Out of range ({{min}}–{{max}})"
   }
 }

--- a/src/renderer/i18n/index.ts
+++ b/src/renderer/i18n/index.ts
@@ -54,13 +54,23 @@ export function initI18n(): void {
  * Translation helper. Thin wrapper over `i18next.t` so call sites don't need
  * to import i18next directly and we can swap the backing lib later without
  * a widespread refactor.
+ *
+ * Accepts an optional `options` bag for interpolation — e.g.
+ * `t('parameters.invalid', { min: '2', max: '20' })` looks up the key and
+ * substitutes `{{min}}` / `{{max}}` in the resolved string. Values are
+ * stringified by i18next; the escapeValue:false setting applies (safe
+ * because we only ever assign results to `textContent`, never to innerHTML).
  */
-export function t(key: string): string {
+export function t(
+  key: string,
+  options?: Record<string, string | number>,
+): string {
   if (!i18next.isInitialized) {
     initI18n();
   }
-  // i18next's `t()` returns string when called with a plain key + no options.
-  return i18next.t(key);
+  // i18next's `t()` returns string when called with a plain key + optional
+  // interpolation options (`returnObjects` is not enabled).
+  return options ? i18next.t(key, options) : i18next.t(key);
 }
 
 /**

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -17,6 +17,7 @@
         --accent: #4a9eff;
         --border: #333333;
         --topbar-h: 48px;
+        --sidebar-w: 280px;
       }
       * {
         box-sizing: border-box;
@@ -119,12 +120,107 @@
       .units-toggle button:hover:not(.is-active) {
         color: var(--fg);
       }
-      #viewport {
+      /* ---- Body layout: viewport + sidebar grid -------------------------- */
+      #body {
         flex: 1 1 auto;
+        display: grid;
+        grid-template-columns: 1fr var(--sidebar-w);
+        min-height: 0;
+      }
+      #viewport {
         position: relative;
         overflow: hidden;
         background: var(--bg);
         /* The WebGL canvas inherits 100%/100% from its own inline styles. */
+      }
+
+      /* ---- Right sidebar: mold parameters ------------------------------- */
+      #sidebar {
+        border-left: 1px solid var(--border);
+        background: var(--bg);
+        color: var(--fg);
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        padding: 16px;
+        overflow-y: auto;
+      }
+      .sidebar__title {
+        margin: 0 0 4px 0;
+        font-size: 13px;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+        color: var(--muted);
+      }
+      .sidebar__form {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        margin: 0;
+        padding: 0;
+        border: none;
+      }
+      .param-field {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .param-field__label {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        font-size: 12px;
+        color: var(--muted);
+      }
+      .param-field__label label {
+        font-size: 12px;
+        color: var(--muted);
+      }
+      .param-field__unit {
+        font-size: 11px;
+        color: var(--muted);
+        font-variant-numeric: tabular-nums;
+      }
+      .param-field__input,
+      .param-field__select {
+        appearance: none;
+        background: transparent;
+        color: var(--fg);
+        border: 1px solid var(--border);
+        padding: 6px 8px;
+        border-radius: 6px;
+        font: inherit;
+        font-size: 13px;
+        font-variant-numeric: tabular-nums;
+        width: 100%;
+      }
+      .param-field__input:focus,
+      .param-field__select:focus {
+        outline: 2px solid var(--accent);
+        outline-offset: 1px;
+        border-color: var(--accent);
+      }
+      .param-field__input[aria-invalid='true'] {
+        border-color: #e06c75;
+      }
+      .param-field__error {
+        color: #e06c75;
+        font-size: 11px;
+        min-height: 1em;
+      }
+      .sidebar__reset {
+        margin-top: auto;
+        align-self: stretch;
+      }
+      /* Firefox: hide number-input spin buttons — the kb-arrows still work. */
+      .param-field__input::-webkit-outer-spin-button,
+      .param-field__input::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+      }
+      .param-field__input[type='number'] {
+        -moz-appearance: textfield;
       }
       button {
         appearance: none;
@@ -150,7 +246,12 @@
       <header class="topbar" data-testid="topbar">
         <!-- Populated by src/renderer/ui/topbar.ts on DOMContentLoaded -->
       </header>
-      <div id="viewport" data-testid="viewport"></div>
+      <div id="body">
+        <div id="viewport" data-testid="viewport"></div>
+        <aside id="sidebar" data-testid="sidebar">
+          <!-- Populated by src/renderer/ui/parameters/panel.ts on DOMContentLoaded -->
+        </aside>
+      </div>
     </div>
     <script type="module" src="./main.ts"></script>
   </body>

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -13,10 +13,20 @@
 
 import { mount, type MountedViewport } from './scene/viewport';
 import { initI18n } from './i18n';
+import {
+  createParametersStore,
+  type ParametersStore,
+} from './state/parameters';
+import {
+  mountParameterPanel,
+  type ParameterPanelApi,
+} from './ui/parameters/panel';
 import { mountTopbar, type TopbarApi } from './ui/topbar';
 
 let topbar: TopbarApi | null = null;
 let viewport: MountedViewport | null = null;
+let parametersStore: ParametersStore | null = null;
+let parameterPanel: ParameterPanelApi | null = null;
 
 async function hydrateVersion(): Promise<void> {
   // The topbar owns the `[data-testid="app-version"]` element now; keep
@@ -59,6 +69,38 @@ function mountViewport(): void {
     return;
   }
   viewport = mount(container);
+}
+
+/**
+ * Create the parameters store and mount the right-sidebar panel. Called
+ * after i18n init so all labels resolve. The store is the single source of
+ * truth that Phase 3c's mold generator will read from.
+ *
+ * Exposed on `window.__testHooks.parameters` under `NODE_ENV === 'test'` so
+ * visual + E2E specs can drive or inspect state without clicking fields.
+ */
+function mountParameters(): void {
+  const container = document.getElementById('sidebar');
+  if (!container) {
+    console.error(
+      'Missing #sidebar container — renderer HTML is out of date.',
+    );
+    return;
+  }
+  parametersStore = createParametersStore();
+  parameterPanel = mountParameterPanel(container, parametersStore);
+
+  if (process.env.NODE_ENV === 'test') {
+    const w = window as unknown as {
+      __testHooks?: Record<string, unknown>;
+    };
+    const hooks = (w.__testHooks ??= {});
+    hooks['parameters'] = parametersStore;
+  }
+  // Silence unused-var lint for the panel handle — we need the reference
+  // to prevent early GC of its listeners, and to give future shutdown
+  // hooks a place to call destroy().
+  void parameterPanel;
 }
 
 /**
@@ -142,6 +184,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initI18n();
   mountUi();
   mountViewport();
+  mountParameters();
   wireOpenStlButton();
   void hydrateVersion();
 });

--- a/src/renderer/state/parameters.ts
+++ b/src/renderer/state/parameters.ts
@@ -1,0 +1,224 @@
+// src/renderer/state/parameters.ts
+//
+// The single source of truth for mold-generation parameters selected by the
+// user in the right sidebar. This module is pure state — no DOM, no i18n,
+// no geometry. The Phase 3c mold generator will consume `get()` at the
+// moment the user presses the (not-yet-wired) Generate button.
+//
+// Design notes
+// ------------
+//
+// * Units policy. Every length field is stored in millimetres, with the
+//   `-_mm` suffix on the key making the unit load-bearing at the call site
+//   (the sidebar form converts to / from inches purely at the display
+//   boundary — see `src/renderer/ui/formatters.ts`). Angles are always
+//   degrees.
+//
+// * No runtime dep for state management. The app's vanilla-TS posture
+//   matches the topbar + units-toggle modules; introducing Zustand / Redux
+//   for ~8 scalar fields would be disproportionate. If, during Phase 3d+,
+//   the state graph grows beyond what a plain `Set<listener>` can serve,
+//   we'll revisit via ADR.
+//
+// * Listener semantics. `subscribe(fn)` returns an unsubscribe callable.
+//   Listeners fire synchronously inside `update()` / `reset()` after the
+//   internal object is replaced. The listener receives the new readonly
+//   snapshot; mutating it has no effect on the store (the reference is
+//   frozen via `Object.freeze`).
+//
+// * Ranges from docs/research/molding-techniques.md §6 ("Recommendation
+//   for v1 — APPROVED 2026-04-18"). The issue-body numeric table was
+//   superseded per the agent clarification posted on #31: the research doc
+//   is the authoritative source when the two disagree (and the issue's own
+//   instruction says so verbatim). See PR body for details.
+//
+// * Validation. Ranges live next to the defaults so the panel can render
+//   "Out of range (min–max)" error messages and clamp on blur without
+//   importing a schema library.
+
+export type RegistrationKeyStyle = 'asymmetric-hemi' | 'cone' | 'keyhole';
+
+export interface MoldParameters {
+  /** Silicone wall thickness in mm. */
+  wallThickness_mm: number;
+  /** Printed base plate thickness in mm. */
+  baseThickness_mm: number;
+  /** Number of printed side walls: 2, 3, or 4. */
+  sideCount: 2 | 3 | 4;
+  /** Resin pour-funnel diameter in mm. */
+  sprueDiameter_mm: number;
+  /** Air-escape vent diameter in mm. */
+  ventDiameter_mm: number;
+  /** Number of vent channels (auto-placement later). */
+  ventCount: number;
+  /** Registration-key shape for mating faces. */
+  registrationKeyStyle: RegistrationKeyStyle;
+  /** Draft angle in degrees. Always unit-agnostic. */
+  draftAngle_deg: number;
+}
+
+/**
+ * Numeric constraint per field. Step is used by the input's `step` attribute
+ * for keyboard arrows. All numbers are mm for lengths, degrees for angles.
+ */
+export interface NumericConstraint {
+  min: number;
+  max: number;
+  step: number;
+  /** Integer-only flag (e.g. ventCount). */
+  integer: boolean;
+}
+
+/**
+ * Defaults APPROVED 2026-04-18 at the Phase-0 gate per
+ * `docs/research/molding-techniques.md §6`. The issue-31 numeric table
+ * conflicted with this doc; the research doc wins (the issue body says so
+ * explicitly: "if a doc contradicts the table, the table is wrong").
+ *
+ * `ventCount` is not specified in the research doc; we keep the issue
+ * table's default of 2 and range 0–8.
+ */
+export const DEFAULT_PARAMETERS: Readonly<MoldParameters> = Object.freeze({
+  wallThickness_mm: 10,
+  baseThickness_mm: 5,
+  sideCount: 4,
+  sprueDiameter_mm: 5,
+  ventDiameter_mm: 1.5,
+  ventCount: 2,
+  registrationKeyStyle: 'asymmetric-hemi',
+  draftAngle_deg: 0,
+});
+
+/**
+ * Numeric constraints for the validators + clamp-on-blur behaviour.
+ * Kept alongside the defaults so a single edit here updates both the UI
+ * form validation and any downstream consumer that wants to know the
+ * legal range.
+ */
+export const NUMERIC_CONSTRAINTS: Readonly<
+  Record<keyof Pick<MoldParameters,
+    | 'wallThickness_mm'
+    | 'baseThickness_mm'
+    | 'sprueDiameter_mm'
+    | 'ventDiameter_mm'
+    | 'ventCount'
+    | 'draftAngle_deg'
+  >, NumericConstraint>
+> = Object.freeze({
+  wallThickness_mm: { min: 6, max: 25, step: 0.5, integer: false },
+  baseThickness_mm: { min: 2, max: 15, step: 0.5, integer: false },
+  sprueDiameter_mm: { min: 3, max: 8, step: 0.5, integer: false },
+  ventDiameter_mm: { min: 1, max: 3, step: 0.5, integer: false },
+  ventCount: { min: 0, max: 8, step: 1, integer: true },
+  draftAngle_deg: { min: 0, max: 3, step: 0.5, integer: false },
+});
+
+/** Allowed enum values for `sideCount`. */
+export const SIDE_COUNT_OPTIONS: ReadonlyArray<2 | 3 | 4> = Object.freeze([
+  2, 3, 4,
+]);
+
+/** Allowed enum values for `registrationKeyStyle`. */
+export const KEY_STYLE_OPTIONS: ReadonlyArray<RegistrationKeyStyle> =
+  Object.freeze(['asymmetric-hemi', 'cone', 'keyhole']);
+
+export type ParametersListener = (
+  parameters: Readonly<MoldParameters>,
+) => void;
+
+export interface ParametersStore {
+  /** Current snapshot. Frozen — mutating it is a no-op. */
+  get(): Readonly<MoldParameters>;
+  /**
+   * Merge a partial patch into the store. Listeners fire synchronously
+   * with the new frozen snapshot. Values are trusted — range clamping is
+   * the UI layer's responsibility (clamp-on-blur).
+   */
+  update(patch: Partial<MoldParameters>): void;
+  /** Reset every field to its default. Listeners fire. */
+  reset(): void;
+  /**
+   * Subscribe to state changes. Returns an unsubscribe callable. Same
+   * listener added twice is de-duplicated (Set semantics).
+   */
+  subscribe(listener: ParametersListener): () => void;
+  /**
+   * Whether every field currently equals its default. Used by the panel
+   * to disable the "Reset to defaults" button when there is nothing to
+   * reset.
+   */
+  isAtDefaults(): boolean;
+}
+
+/**
+ * Strict key-by-key equality for parameter snapshots. We intentionally
+ * don't import a deep-equal library — the shape is small, flat, and made
+ * of primitives, so triple-equals suffices.
+ */
+function equals(a: MoldParameters, b: MoldParameters): boolean {
+  return (
+    a.wallThickness_mm === b.wallThickness_mm &&
+    a.baseThickness_mm === b.baseThickness_mm &&
+    a.sideCount === b.sideCount &&
+    a.sprueDiameter_mm === b.sprueDiameter_mm &&
+    a.ventDiameter_mm === b.ventDiameter_mm &&
+    a.ventCount === b.ventCount &&
+    a.registrationKeyStyle === b.registrationKeyStyle &&
+    a.draftAngle_deg === b.draftAngle_deg
+  );
+}
+
+/**
+ * Construct a parameters store. `initial` is shallow-merged over the
+ * defaults. Useful for tests; the app wires `createParametersStore()`
+ * with no argument.
+ */
+export function createParametersStore(
+  initial?: Partial<MoldParameters>,
+): ParametersStore {
+  let current: Readonly<MoldParameters> = Object.freeze({
+    ...DEFAULT_PARAMETERS,
+    ...(initial ?? {}),
+  });
+  const listeners = new Set<ParametersListener>();
+
+  const notify = (): void => {
+    for (const listener of listeners) {
+      try {
+        listener(current);
+      } catch (err) {
+        // A single bad subscriber should not break the store for others.
+        // Log and continue; this matches the behaviour of well-behaved
+        // observable implementations.
+        console.error('[parameters] listener threw:', err);
+      }
+    }
+  };
+
+  return {
+    get(): Readonly<MoldParameters> {
+      return current;
+    },
+    update(patch: Partial<MoldParameters>): void {
+      const next = Object.freeze({ ...current, ...patch }) as Readonly<MoldParameters>;
+      if (equals(current, next)) return;
+      current = next;
+      notify();
+    },
+    reset(): void {
+      const next = Object.freeze({ ...DEFAULT_PARAMETERS });
+      if (equals(current, next)) return;
+      current = next;
+      notify();
+    },
+    subscribe(listener: ParametersListener): () => void {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    isAtDefaults(): boolean {
+      return equals(current, DEFAULT_PARAMETERS);
+    },
+  };
+}

--- a/src/renderer/ui/formatters.ts
+++ b/src/renderer/ui/formatters.ts
@@ -26,6 +26,9 @@ export type UnitSystem = 'mm' | 'in';
 /** mm³ per in³. Pinned so the conversion is trivially auditable. */
 const MM3_PER_IN3 = 25.4 ** 3; // 16387.064
 
+/** mm per in. The single source of truth for length conversion. */
+const MM_PER_IN = 25.4;
+
 /**
  * en-US integer formatter for mm³. Thousands grouped with comma, no decimals.
  * Rounds half-away-from-zero per `Intl.NumberFormat`'s default rounding mode
@@ -68,4 +71,72 @@ export function formatVolume(mm3: number | null, unit: UnitSystem): string {
 
   // Default / mm branch.
   return `${MM3_FORMATTER.format(mm3)} mm\u00B3`;
+}
+
+// ----------------------------------------------------------------------------
+// Length formatters (parameter form).
+//
+// Unlike `formatVolume` (which is locale-grouped + unit-suffixed for a readout
+// display), lengths are displayed inside <input type="number"> fields. Number
+// inputs parse with `.` as the decimal separator and ignore grouping
+// separators. So these functions deliberately produce:
+//
+//   - NO thousands separators (e.g. 1234.5 → "1234.5", NOT "1,234.5")
+//   - NO unit suffix (the field renders the unit in a sibling label)
+//   - Fixed decimal places per unit system: 1 for mm, 3 for inches
+//     (0.05" ≈ 1.27 mm, so 3 decimal places covers the whole 2–25 mm range
+//     without loss when a user flips mm→in→mm)
+//
+// Parsing is permissive: trims whitespace, accepts `,` or `.` as decimal
+// separator (common in en-GB / de-DE locales even though we pin en-US for
+// display). Returns NaN on anything unparseable — callers clamp NaN to the
+// default, per issue #31 UX contract.
+// ----------------------------------------------------------------------------
+
+/** Tolerance for the `parseLength(formatLength(x, u), u) === x` round-trip in tests. */
+export const LENGTH_ROUND_TRIP_ABS_TOL_MM = 1e-4;
+
+/**
+ * Format a length in mm for display in a number input.
+ *
+ * @param mm   Length in mm. Internal storage unit.
+ * @param unit Active unit system. In `'mm'` returns the mm value with 1
+ *             decimal; in `'in'` converts to inches and returns with 3
+ *             decimals. No grouping separators. No unit suffix.
+ *
+ * @returns    Plain numeric string suitable for an `<input type="number">`
+ *             `.value`, or empty string if `mm` is non-finite.
+ */
+export function formatLength(mm: number, unit: UnitSystem): string {
+  if (!Number.isFinite(mm)) return '';
+  if (unit === 'in') {
+    const inches = mm / MM_PER_IN;
+    return inches.toFixed(3);
+  }
+  return mm.toFixed(1);
+}
+
+/**
+ * Parse a user-entered length string and return the value in mm.
+ *
+ * @param text Raw input text. Trimmed; accepts '.' or ',' as decimal.
+ * @param unit Active unit system that the text is expressed in. If 'in',
+ *             the numeric part is multiplied by 25.4 to reach mm.
+ *
+ * @returns    Length in mm, or NaN if the text cannot be parsed as a
+ *             finite number. Negative values are permitted by the
+ *             formatter (they round-trip cleanly) and left to range-
+ *             checking at the field level — we don't clamp sign here.
+ */
+export function parseLength(text: string, unit: UnitSystem): number {
+  if (typeof text !== 'string') return Number.NaN;
+  const trimmed = text.trim();
+  if (trimmed === '') return Number.NaN;
+  // Normalise locale comma to dot before parsing. Avoids surprising the
+  // German / French / Finnish / etc. users who reflexively type `6,35`.
+  const normalised = trimmed.replace(',', '.');
+  const n = Number(normalised);
+  if (!Number.isFinite(n)) return Number.NaN;
+  if (unit === 'in') return n * MM_PER_IN;
+  return n;
 }

--- a/src/renderer/ui/parameters/field.ts
+++ b/src/renderer/ui/parameters/field.ts
@@ -1,0 +1,372 @@
+// src/renderer/ui/parameters/field.ts
+//
+// Factory functions that produce the two flavours of parameter input used in
+// the right sidebar:
+//
+//   * NumberField  — numeric input with optional unit suffix, inline error,
+//                    and clamp-on-blur semantics. Lengths are unit-aware
+//                    (mm / inches); non-length fields (ventCount, draftAngle)
+//                    use a `unitSymbol` string rendered next to the input
+//                    regardless of the active unit system.
+//   * SelectField  — <select> wrapper for `sideCount` (2/3/4) and
+//                    `registrationKeyStyle` (the three enum values).
+//
+// There is no component framework. The factories return a plain
+// `{ element, setValue, setError, destroy, ... }` handle; the sidebar
+// panel composes them into a form.
+//
+// Validation policy
+// -----------------
+// The sidebar must NOT prevent typing out-of-range values — doing so makes
+// the input feel broken when users try to retype a value (e.g. to change
+// "8.5" into "12.5" they momentarily need "8" or "1" in the box). Instead
+// we surface the range as a visible error the moment the user finishes
+// typing a bad value, and on blur we silently clamp to the nearest legal
+// value. This matches the UX convention documented in issue #31.
+
+import { t } from '../../i18n';
+import type { UnitSystem } from '../../i18n';
+
+/** Length unit category — lengths follow the mm/inches toggle; everything else doesn't. */
+export type NumberFieldKind = 'length' | 'angle' | 'count';
+
+export interface NumberFieldConfig {
+  /** Stable DOM id, also used as testid suffix. */
+  id: string;
+  /** Translated label (already passed through i18n). */
+  label: string;
+  /** Valid range in the INTERNAL unit — mm for lengths, degrees for angles, integer count otherwise. */
+  min: number;
+  max: number;
+  /** Keyboard step. */
+  step: number;
+  /** Whether values must be integer. Only true for ventCount in practice. */
+  integer: boolean;
+  /** Tells the formatter whether to bridge mm ↔ inches. */
+  kind: NumberFieldKind;
+  /**
+   * Unit suffix displayed next to the input. For 'length' fields this is
+   * `null` — the panel driver updates the suffix from the active unit
+   * system. For 'angle' we always show `°`. For 'count' we omit the suffix.
+   */
+  unitSymbol: string | null;
+  /** Initial value in the INTERNAL unit (mm for lengths, deg for angle, int for count). */
+  initial: number;
+  /** Callback fired when the user has committed a legal value (on blur / change). */
+  onCommit(internalValue: number): void;
+}
+
+export interface NumberFieldHandle {
+  /** The outermost <div> wrapping label + input + error. */
+  readonly element: HTMLDivElement;
+  /**
+   * Programmatically set the value. Used (a) when the topbar flips units
+   * so length fields redisplay, and (b) when the user clicks "Reset to
+   * defaults". The value is in the internal unit; the field renders it
+   * through the configured formatter.
+   */
+  setValue(internalValue: number): void;
+  /** Display (or clear) an inline error message. */
+  setError(message: string | null): void;
+  /** For length fields only: switch the displayed unit system. */
+  setUnitSystem(unit: UnitSystem): void;
+  /** Detach listeners. */
+  destroy(): void;
+}
+
+export interface SelectFieldOption<V extends string> {
+  /** Stable value, e.g. "asymmetric-hemi" or "4". */
+  value: V;
+  /** Translated label. */
+  label: string;
+}
+
+export interface SelectFieldConfig<V extends string> {
+  id: string;
+  label: string;
+  options: ReadonlyArray<SelectFieldOption<V>>;
+  initial: V;
+  onChange(value: V): void;
+}
+
+export interface SelectFieldHandle<V extends string> {
+  readonly element: HTMLDivElement;
+  setValue(value: V): void;
+  destroy(): void;
+}
+
+// ----------------------------------------------------------------------------
+// Formatting bridge
+//
+// We intentionally import `formatLength` / `parseLength` only for the length
+// branch so Vitest tests of angle/count fields don't need the units toggle.
+// `kind === 'angle' | 'count'` uses the raw internal number for display.
+// ----------------------------------------------------------------------------
+
+import { formatLength, parseLength } from '../formatters';
+
+/** Convert an internal value to input-box text for the current unit system. */
+function renderValue(
+  internalValue: number,
+  kind: NumberFieldKind,
+  unitSystem: UnitSystem,
+  integer: boolean,
+): string {
+  if (!Number.isFinite(internalValue)) return '';
+  if (kind === 'length') return formatLength(internalValue, unitSystem);
+  if (integer) return String(Math.round(internalValue));
+  // Angle: always degrees, one decimal place.
+  return internalValue.toFixed(1);
+}
+
+/** Parse input-box text into an internal-unit value, or NaN on failure. */
+function parseValue(
+  text: string,
+  kind: NumberFieldKind,
+  unitSystem: UnitSystem,
+  integer: boolean,
+): number {
+  if (kind === 'length') return parseLength(text, unitSystem);
+  const trimmed = text.trim().replace(',', '.');
+  if (trimmed === '') return Number.NaN;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n)) return Number.NaN;
+  if (integer) return Math.trunc(n);
+  return n;
+}
+
+/** True when `internalValue` is inside the legal `[min, max]` range. */
+function inRange(internalValue: number, min: number, max: number): boolean {
+  return (
+    Number.isFinite(internalValue) &&
+    internalValue >= min &&
+    internalValue <= max
+  );
+}
+
+/** Clamp `n` into `[min, max]`, returning `min` when `n` is non-finite. */
+function clamp(n: number, min: number, max: number): number {
+  if (!Number.isFinite(n)) return min;
+  if (n < min) return min;
+  if (n > max) return max;
+  return n;
+}
+
+/**
+ * Build a numeric field. The returned element renders:
+ *
+ *   <div class="param-field">
+ *     <label for="..."><span>label</span><span class="param-field__unit"/></label>
+ *     <input type="number" ... />
+ *     <small class="param-field__error" role="alert" hidden>...</small>
+ *   </div>
+ */
+export function createNumberField(
+  config: NumberFieldConfig,
+): NumberFieldHandle {
+  const {
+    id,
+    label,
+    min,
+    max,
+    step,
+    integer,
+    kind,
+    unitSymbol,
+    initial,
+    onCommit,
+  } = config;
+
+  const wrap = document.createElement('div');
+  wrap.className = 'param-field';
+  wrap.dataset['testid'] = `param-field-${id}`;
+
+  const labelRow = document.createElement('div');
+  labelRow.className = 'param-field__label';
+
+  const labelEl = document.createElement('label');
+  labelEl.setAttribute('for', id);
+  labelEl.textContent = label;
+
+  const unitEl = document.createElement('span');
+  unitEl.className = 'param-field__unit';
+  // Unit label is managed by `setUnitSystem` for length fields; the initial
+  // text is whatever the caller passes in unitSymbol (or 'mm' for lengths;
+  // the panel will override post-construction via setUnitSystem).
+  unitEl.textContent =
+    unitSymbol ?? (kind === 'length' ? t('units.mm') : '');
+
+  labelRow.appendChild(labelEl);
+  labelRow.appendChild(unitEl);
+  wrap.appendChild(labelRow);
+
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.id = id;
+  input.className = 'param-field__input';
+  input.dataset['testid'] = `param-input-${id}`;
+  input.step = String(step);
+  // We don't set min/max as HTML attributes — doing so would let the input
+  // clamp on arrow-key step and silently change the value in ways the user
+  // didn't request. Validation lives in JS per the issue's clamp-on-blur rule.
+  input.inputMode = integer ? 'numeric' : 'decimal';
+
+  let unitSystem: UnitSystem = kind === 'length' ? 'mm' : 'mm';
+  // ^ sentinel — mm is the default; the panel resets this via setUnitSystem
+  // on mount so the field matches the topbar toggle.
+
+  let internalValue = initial;
+  input.value = renderValue(internalValue, kind, unitSystem, integer);
+
+  wrap.appendChild(input);
+
+  const error = document.createElement('small');
+  error.className = 'param-field__error';
+  error.dataset['testid'] = `param-error-${id}`;
+  error.setAttribute('role', 'alert');
+  error.hidden = true;
+  wrap.appendChild(error);
+
+  function setError(message: string | null): void {
+    if (message === null) {
+      error.hidden = true;
+      error.textContent = '';
+      input.removeAttribute('aria-invalid');
+    } else {
+      error.hidden = false;
+      error.textContent = message;
+      input.setAttribute('aria-invalid', 'true');
+    }
+  }
+
+  function validateLive(): void {
+    const parsed = parseValue(input.value, kind, unitSystem, integer);
+    if (inRange(parsed, min, max)) {
+      setError(null);
+    } else {
+      // Build the range message in DISPLAY units so the user sees what they
+      // actually typed in. `formatLength` handles mm ↔ inches; angle/count
+      // simply render the raw number.
+      setError(buildRangeMessage(min, max, kind, unitSystem, integer));
+    }
+  }
+
+  function commitClamped(): void {
+    const parsed = parseValue(input.value, kind, unitSystem, integer);
+    const clamped = clamp(parsed, min, max);
+    // Normalise integer fields.
+    const normalised = integer ? Math.round(clamped) : clamped;
+    internalValue = normalised;
+    input.value = renderValue(internalValue, kind, unitSystem, integer);
+    setError(null);
+    onCommit(internalValue);
+  }
+
+  input.addEventListener('input', () => {
+    validateLive();
+  });
+  input.addEventListener('blur', () => {
+    commitClamped();
+  });
+  // Also commit on `change` — covers the keyboard-arrow step case where the
+  // input fires `change` without `blur`.
+  input.addEventListener('change', () => {
+    commitClamped();
+  });
+
+  return {
+    element: wrap,
+    setValue(value: number): void {
+      internalValue = value;
+      input.value = renderValue(internalValue, kind, unitSystem, integer);
+      setError(null);
+    },
+    setError(message: string | null): void {
+      setError(message);
+    },
+    setUnitSystem(unit: UnitSystem): void {
+      if (kind !== 'length') return;
+      unitSystem = unit;
+      unitEl.textContent = unit === 'in' ? t('units.in') : t('units.mm');
+      // Re-render the CURRENT internal value in the new unit. The internal
+      // mm value is unchanged, so there's no precision loss.
+      input.value = renderValue(internalValue, kind, unitSystem, integer);
+      // If the field was showing a stale error, refresh it in the new unit.
+      validateLive();
+    },
+    destroy(): void {
+      // Event listeners are attached via anonymous fns, but since we never
+      // re-use the same input we just detach the whole element. If the
+      // panel replaces the sidebar at runtime (post-v1), wire an
+      // AbortController here.
+      wrap.remove();
+    },
+  };
+}
+
+/**
+ * Build a <select> field. Simpler than NumberField — no unit awareness, no
+ * clamp-on-blur, no inline error (enums are always valid by construction).
+ */
+export function createSelectField<V extends string>(
+  config: SelectFieldConfig<V>,
+): SelectFieldHandle<V> {
+  const { id, label, options, initial, onChange } = config;
+
+  const wrap = document.createElement('div');
+  wrap.className = 'param-field';
+  wrap.dataset['testid'] = `param-field-${id}`;
+
+  const labelRow = document.createElement('div');
+  labelRow.className = 'param-field__label';
+  const labelEl = document.createElement('label');
+  labelEl.setAttribute('for', id);
+  labelEl.textContent = label;
+  labelRow.appendChild(labelEl);
+  wrap.appendChild(labelRow);
+
+  const select = document.createElement('select');
+  select.id = id;
+  select.className = 'param-field__select';
+  select.dataset['testid'] = `param-input-${id}`;
+
+  for (const opt of options) {
+    const option = document.createElement('option');
+    option.value = opt.value;
+    option.textContent = opt.label;
+    select.appendChild(option);
+  }
+  select.value = initial;
+  wrap.appendChild(select);
+
+  select.addEventListener('change', () => {
+    onChange(select.value as V);
+  });
+
+  return {
+    element: wrap,
+    setValue(value: V): void {
+      select.value = value;
+    },
+    destroy(): void {
+      wrap.remove();
+    },
+  };
+}
+
+/**
+ * Build the user-visible "Out of range (min–max)" message in the active
+ * display unit. Split out so both the live validator and the panel-level
+ * driver can reuse it.
+ */
+function buildRangeMessage(
+  minInternal: number,
+  maxInternal: number,
+  kind: NumberFieldKind,
+  unitSystem: UnitSystem,
+  integer: boolean,
+): string {
+  const minDisplay = renderValue(minInternal, kind, unitSystem, integer);
+  const maxDisplay = renderValue(maxInternal, kind, unitSystem, integer);
+  return t('parameters.invalid', { min: minDisplay, max: maxDisplay });
+}

--- a/src/renderer/ui/parameters/panel.ts
+++ b/src/renderer/ui/parameters/panel.ts
@@ -1,0 +1,270 @@
+// src/renderer/ui/parameters/panel.ts
+//
+// The right-sidebar mold-parameter form. Binds the `ParametersStore` to a
+// stack of NumberField + SelectField instances, wires the "Reset to
+// defaults" button, and keeps length fields in sync with the topbar's
+// mm/inches toggle via the `units-changed` CustomEvent.
+//
+// This panel is mount-once, destroy-on-app-shutdown. It owns no geometry
+// state — downstream consumers (Phase 3c+) will read from the store the
+// panel was constructed with.
+//
+// Layout (plain DOM, no framework):
+//
+//   <aside class="sidebar">
+//     <h2 class="sidebar__title">Mold parameters</h2>
+//     <form class="sidebar__form">
+//       <NumberField wall />
+//       <NumberField base />
+//       <SelectField sideCount />
+//       <NumberField sprue />
+//       <NumberField vent />
+//       <NumberField ventCount />
+//       <SelectField keyStyle />
+//       <NumberField draft />
+//     </form>
+//     <button class="sidebar__reset" />
+//   </aside>
+
+import { getUnitSystem, t, type UnitSystem } from '../../i18n';
+import {
+  DEFAULT_PARAMETERS,
+  KEY_STYLE_OPTIONS,
+  NUMERIC_CONSTRAINTS,
+  SIDE_COUNT_OPTIONS,
+  type MoldParameters,
+  type ParametersStore,
+  type RegistrationKeyStyle,
+} from '../../state/parameters';
+import {
+  createNumberField,
+  createSelectField,
+  type NumberFieldHandle,
+  type SelectFieldHandle,
+} from './field';
+
+export interface ParameterPanelApi {
+  /** Detach the panel + listeners. */
+  destroy(): void;
+}
+
+/**
+ * Mount the parameter panel into `container`. The container is expected to
+ * be the `<aside id="sidebar">` element already present in `index.html`.
+ * We append into it rather than replacing the children, so any error
+ * fallback content in the HTML stays visible if the mount fails.
+ */
+export function mountParameterPanel(
+  container: HTMLElement,
+  store: ParametersStore,
+): ParameterPanelApi {
+  container.textContent = '';
+  container.classList.add('sidebar');
+
+  // ---- Title -----------------------------------------------------------------
+  const title = document.createElement('h2');
+  title.className = 'sidebar__title';
+  title.textContent = t('parameters.title');
+  container.appendChild(title);
+
+  // ---- Form -----------------------------------------------------------------
+  const form = document.createElement('form');
+  form.className = 'sidebar__form';
+  // Form is never submitted — it's just a semantic group wrapper. Prevent
+  // the default browser submit-on-Enter so a keyboard user doesn't reload
+  // the page or trigger an unexpected side-effect.
+  form.addEventListener('submit', (ev) => {
+    ev.preventDefault();
+  });
+  container.appendChild(form);
+
+  const handles: {
+    wallThickness_mm: NumberFieldHandle;
+    baseThickness_mm: NumberFieldHandle;
+    sideCount: SelectFieldHandle<string>;
+    sprueDiameter_mm: NumberFieldHandle;
+    ventDiameter_mm: NumberFieldHandle;
+    ventCount: NumberFieldHandle;
+    registrationKeyStyle: SelectFieldHandle<RegistrationKeyStyle>;
+    draftAngle_deg: NumberFieldHandle;
+  } = {
+    wallThickness_mm: createNumberField({
+      id: 'wallThickness',
+      label: t('parameters.wall'),
+      kind: 'length',
+      unitSymbol: null,
+      min: NUMERIC_CONSTRAINTS.wallThickness_mm.min,
+      max: NUMERIC_CONSTRAINTS.wallThickness_mm.max,
+      step: NUMERIC_CONSTRAINTS.wallThickness_mm.step,
+      integer: NUMERIC_CONSTRAINTS.wallThickness_mm.integer,
+      initial: DEFAULT_PARAMETERS.wallThickness_mm,
+      onCommit: (value) => store.update({ wallThickness_mm: value }),
+    }),
+    baseThickness_mm: createNumberField({
+      id: 'baseThickness',
+      label: t('parameters.base'),
+      kind: 'length',
+      unitSymbol: null,
+      min: NUMERIC_CONSTRAINTS.baseThickness_mm.min,
+      max: NUMERIC_CONSTRAINTS.baseThickness_mm.max,
+      step: NUMERIC_CONSTRAINTS.baseThickness_mm.step,
+      integer: NUMERIC_CONSTRAINTS.baseThickness_mm.integer,
+      initial: DEFAULT_PARAMETERS.baseThickness_mm,
+      onCommit: (value) => store.update({ baseThickness_mm: value }),
+    }),
+    sideCount: createSelectField<string>({
+      id: 'sideCount',
+      label: t('parameters.sideCount'),
+      options: SIDE_COUNT_OPTIONS.map((n) => ({
+        value: String(n),
+        label: String(n),
+      })),
+      initial: String(DEFAULT_PARAMETERS.sideCount),
+      onChange: (value) => {
+        const n = Number(value);
+        if (n === 2 || n === 3 || n === 4) {
+          store.update({ sideCount: n });
+        }
+      },
+    }),
+    sprueDiameter_mm: createNumberField({
+      id: 'sprueDiameter',
+      label: t('parameters.sprue'),
+      kind: 'length',
+      unitSymbol: null,
+      min: NUMERIC_CONSTRAINTS.sprueDiameter_mm.min,
+      max: NUMERIC_CONSTRAINTS.sprueDiameter_mm.max,
+      step: NUMERIC_CONSTRAINTS.sprueDiameter_mm.step,
+      integer: NUMERIC_CONSTRAINTS.sprueDiameter_mm.integer,
+      initial: DEFAULT_PARAMETERS.sprueDiameter_mm,
+      onCommit: (value) => store.update({ sprueDiameter_mm: value }),
+    }),
+    ventDiameter_mm: createNumberField({
+      id: 'ventDiameter',
+      label: t('parameters.vent'),
+      kind: 'length',
+      unitSymbol: null,
+      min: NUMERIC_CONSTRAINTS.ventDiameter_mm.min,
+      max: NUMERIC_CONSTRAINTS.ventDiameter_mm.max,
+      step: NUMERIC_CONSTRAINTS.ventDiameter_mm.step,
+      integer: NUMERIC_CONSTRAINTS.ventDiameter_mm.integer,
+      initial: DEFAULT_PARAMETERS.ventDiameter_mm,
+      onCommit: (value) => store.update({ ventDiameter_mm: value }),
+    }),
+    ventCount: createNumberField({
+      id: 'ventCount',
+      label: t('parameters.ventCount'),
+      kind: 'count',
+      unitSymbol: '',
+      min: NUMERIC_CONSTRAINTS.ventCount.min,
+      max: NUMERIC_CONSTRAINTS.ventCount.max,
+      step: NUMERIC_CONSTRAINTS.ventCount.step,
+      integer: NUMERIC_CONSTRAINTS.ventCount.integer,
+      initial: DEFAULT_PARAMETERS.ventCount,
+      onCommit: (value) => store.update({ ventCount: value }),
+    }),
+    registrationKeyStyle: createSelectField<RegistrationKeyStyle>({
+      id: 'registrationKeyStyle',
+      label: t('parameters.keyStyle'),
+      options: KEY_STYLE_OPTIONS.map((v) => ({
+        value: v,
+        label: t(`parameters.keyStyleOptions.${v}`),
+      })),
+      initial: DEFAULT_PARAMETERS.registrationKeyStyle,
+      onChange: (value) => store.update({ registrationKeyStyle: value }),
+    }),
+    draftAngle_deg: createNumberField({
+      id: 'draftAngle',
+      label: t('parameters.draft'),
+      kind: 'angle',
+      unitSymbol: t('units.deg'),
+      min: NUMERIC_CONSTRAINTS.draftAngle_deg.min,
+      max: NUMERIC_CONSTRAINTS.draftAngle_deg.max,
+      step: NUMERIC_CONSTRAINTS.draftAngle_deg.step,
+      integer: NUMERIC_CONSTRAINTS.draftAngle_deg.integer,
+      initial: DEFAULT_PARAMETERS.draftAngle_deg,
+      onCommit: (value) => store.update({ draftAngle_deg: value }),
+    }),
+  };
+
+  // Append in spec-order. This is also tab order since the DOM is authoritative.
+  form.appendChild(handles.wallThickness_mm.element);
+  form.appendChild(handles.baseThickness_mm.element);
+  form.appendChild(handles.sideCount.element);
+  form.appendChild(handles.sprueDiameter_mm.element);
+  form.appendChild(handles.ventDiameter_mm.element);
+  form.appendChild(handles.ventCount.element);
+  form.appendChild(handles.registrationKeyStyle.element);
+  form.appendChild(handles.draftAngle_deg.element);
+
+  // ---- Reset-to-defaults button ---------------------------------------------
+  const resetBtn = document.createElement('button');
+  resetBtn.type = 'button';
+  resetBtn.className = 'sidebar__reset';
+  resetBtn.dataset['testid'] = 'param-reset';
+  resetBtn.textContent = t('parameters.reset');
+  resetBtn.addEventListener('click', () => {
+    store.reset();
+  });
+  container.appendChild(resetBtn);
+
+  // Initial disabled state. The store subscription below keeps it in sync.
+  resetBtn.disabled = store.isAtDefaults();
+
+  // ---- Wire: store → fields ------------------------------------------------
+  // When the store changes, push the new values into every field so the
+  // UI reflects external updates (e.g. programmatic reset). This is cheap
+  // — eight DOM assignments per update is fine at the scale we're at.
+  const unsubscribeStore = store.subscribe((p) => {
+    handles.wallThickness_mm.setValue(p.wallThickness_mm);
+    handles.baseThickness_mm.setValue(p.baseThickness_mm);
+    handles.sideCount.setValue(String(p.sideCount));
+    handles.sprueDiameter_mm.setValue(p.sprueDiameter_mm);
+    handles.ventDiameter_mm.setValue(p.ventDiameter_mm);
+    handles.ventCount.setValue(p.ventCount);
+    handles.registrationKeyStyle.setValue(p.registrationKeyStyle);
+    handles.draftAngle_deg.setValue(p.draftAngle_deg);
+    resetBtn.disabled = store.isAtDefaults();
+  });
+
+  // ---- Wire: units toggle → length fields ----------------------------------
+  // Initialise the display unit on mount so length fields show the persisted
+  // unit (e.g. if the user shipped the app with "in" selected last session).
+  const initialUnit = getUnitSystem();
+  applyUnitToLengths(initialUnit);
+
+  const onUnitsChanged = (ev: Event): void => {
+    const detail = (ev as CustomEvent<UnitSystem>).detail;
+    if (detail === 'mm' || detail === 'in') {
+      applyUnitToLengths(detail);
+    }
+  };
+  document.addEventListener('units-changed', onUnitsChanged);
+
+  function applyUnitToLengths(unit: UnitSystem): void {
+    handles.wallThickness_mm.setUnitSystem(unit);
+    handles.baseThickness_mm.setUnitSystem(unit);
+    handles.sprueDiameter_mm.setUnitSystem(unit);
+    handles.ventDiameter_mm.setUnitSystem(unit);
+  }
+
+  return {
+    destroy(): void {
+      document.removeEventListener('units-changed', onUnitsChanged);
+      unsubscribeStore();
+      handles.wallThickness_mm.destroy();
+      handles.baseThickness_mm.destroy();
+      handles.sideCount.destroy();
+      handles.sprueDiameter_mm.destroy();
+      handles.ventDiameter_mm.destroy();
+      handles.ventCount.destroy();
+      handles.registrationKeyStyle.destroy();
+      handles.draftAngle_deg.destroy();
+      resetBtn.remove();
+      title.remove();
+      form.remove();
+    },
+  };
+}
+
+export { type MoldParameters };

--- a/tests/e2e/parameters-clamp.spec.ts
+++ b/tests/e2e/parameters-clamp.spec.ts
@@ -1,0 +1,128 @@
+// tests/e2e/parameters-clamp.spec.ts
+//
+// End-to-end: the right-sidebar parameter form renders inside the Electron
+// renderer, an out-of-range input surfaces the inline error live, and blur
+// clamps the value back into the legal range while clearing the error.
+//
+// Why this lives at the E2E tier (rather than the unit tier that already
+// covers the same behaviour via happy-dom):
+//
+//   * Proves the panel is actually mounted in the production renderer under
+//     Electron — not just in the Vitest jsdom simulacrum. If a future main.ts
+//     change fails to call `mountParameterPanel`, the unit tests would still
+//     pass but this would fail.
+//   * Proves the i18n bundle is actually loaded in the Electron renderer
+//     (labels and error messages come from the resolved keys, not the raw
+//     placeholders).
+//   * Exercises a real native input's focus → blur → change event sequence,
+//     which happy-dom approximates but does not perfectly match.
+
+import { expect, test } from '@playwright/test';
+import { launchApp } from './fixtures/app';
+
+test('sidebar renders with 8 fields + reset button on app launch', async () => {
+  const app = await launchApp();
+  try {
+    const page = await app.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
+
+    // Sidebar container mounts fields inside.
+    await expect(
+      page.locator('[data-testid="sidebar"]'),
+    ).toBeVisible();
+
+    // Every field, every error slot, the reset button — eight inputs.
+    const fieldIds = [
+      'wallThickness',
+      'baseThickness',
+      'sideCount',
+      'sprueDiameter',
+      'ventDiameter',
+      'ventCount',
+      'registrationKeyStyle',
+      'draftAngle',
+    ];
+    for (const id of fieldIds) {
+      await expect(
+        page.locator(`[data-testid="param-input-${id}"]`),
+      ).toBeVisible();
+    }
+
+    // Reset button is disabled on mount (store starts at defaults).
+    const reset = page.locator('[data-testid="param-reset"]');
+    await expect(reset).toBeDisabled();
+
+    // Default wall thickness = 10 mm → renders as "10.0" with the mm unit.
+    await expect(
+      page.locator('[data-testid="param-input-wallThickness"]'),
+    ).toHaveValue('10.0');
+  } finally {
+    await app.close();
+  }
+});
+
+test('out-of-range input shows error live, blur clamps + clears error', async () => {
+  const app = await launchApp();
+  try {
+    const page = await app.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
+
+    const wall = page.locator('[data-testid="param-input-wallThickness"]');
+    const err = page.locator('[data-testid="param-error-wallThickness"]');
+
+    // Clear and type an out-of-range value. Using fill() — it fires 'input'.
+    await wall.fill('99');
+
+    // Error is visible with the clamped range interpolated in mm.
+    await expect(err).toBeVisible();
+    await expect(err).toContainText('6');
+    await expect(err).toContainText('25');
+    await expect(wall).toHaveAttribute('aria-invalid', 'true');
+
+    // Blur the field — clamps to 25 and clears the error.
+    await wall.blur();
+
+    await expect(wall).toHaveValue('25.0');
+    await expect(err).toBeHidden();
+    // aria-invalid attribute is removed on valid state.
+    await expect(wall).not.toHaveAttribute('aria-invalid', 'true');
+
+    // The reset button is now enabled (store moved off defaults).
+    await expect(
+      page.locator('[data-testid="param-reset"]'),
+    ).toBeEnabled();
+  } finally {
+    await app.close();
+  }
+});
+
+test('reset-to-defaults restores every field and disables itself', async () => {
+  const app = await launchApp();
+  try {
+    const page = await app.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
+
+    // Move a couple of fields off-default.
+    await page.locator('[data-testid="param-input-wallThickness"]').fill('15');
+    await page.locator('[data-testid="param-input-wallThickness"]').blur();
+    await page
+      .locator('[data-testid="param-input-sideCount"]')
+      .selectOption('2');
+
+    const reset = page.locator('[data-testid="param-reset"]');
+    await expect(reset).toBeEnabled();
+
+    await reset.click();
+
+    // Defaults restored in the UI, and the button is disabled again.
+    await expect(
+      page.locator('[data-testid="param-input-wallThickness"]'),
+    ).toHaveValue('10.0');
+    await expect(
+      page.locator('[data-testid="param-input-sideCount"]'),
+    ).toHaveValue('4');
+    await expect(reset).toBeDisabled();
+  } finally {
+    await app.close();
+  }
+});

--- a/tests/renderer/length-formatters.test.ts
+++ b/tests/renderer/length-formatters.test.ts
@@ -1,0 +1,106 @@
+// tests/renderer/length-formatters.test.ts
+//
+// Unit tests for `formatLength` / `parseLength`. Complementary to
+// `tests/renderer/formatters.test.ts`, which covers `formatVolume`.
+//
+// These functions sit on the mm ↔ inches display boundary for parameter
+// form inputs. Internal values are always mm; the formatters only exist
+// to present mm in inches without losing round-trip precision.
+
+import { describe, expect, test } from 'vitest';
+
+import {
+  LENGTH_ROUND_TRIP_ABS_TOL_MM,
+  formatLength,
+  parseLength,
+} from '@/renderer/ui/formatters';
+
+describe('formatLength', () => {
+  test('mm → 1 decimal, no grouping', () => {
+    expect(formatLength(10, 'mm')).toBe('10.0');
+    expect(formatLength(1.5, 'mm')).toBe('1.5');
+    expect(formatLength(1234.5, 'mm')).toBe('1234.5');
+  });
+
+  test('inches → 3 decimals', () => {
+    // 25.4 mm is exactly 1 inch.
+    expect(formatLength(25.4, 'in')).toBe('1.000');
+    // 12.7 mm is exactly 0.5 inch.
+    expect(formatLength(12.7, 'in')).toBe('0.500');
+    // 0 mm → 0 inches → "0.000"
+    expect(formatLength(0, 'in')).toBe('0.000');
+  });
+
+  test('non-finite values → empty string (defensive)', () => {
+    expect(formatLength(Number.NaN, 'mm')).toBe('');
+    expect(formatLength(Number.POSITIVE_INFINITY, 'in')).toBe('');
+  });
+
+  test('negative values are preserved (no sign normalisation here)', () => {
+    expect(formatLength(-3, 'mm')).toBe('-3.0');
+    expect(formatLength(-25.4, 'in')).toBe('-1.000');
+  });
+});
+
+describe('parseLength', () => {
+  test('empty / whitespace / junk → NaN', () => {
+    expect(parseLength('', 'mm')).toBeNaN();
+    expect(parseLength('   ', 'mm')).toBeNaN();
+    expect(parseLength('abc', 'mm')).toBeNaN();
+  });
+
+  test('mm pass-through', () => {
+    expect(parseLength('10', 'mm')).toBe(10);
+    expect(parseLength('10.5', 'mm')).toBe(10.5);
+  });
+
+  test('inches → mm', () => {
+    // 1 inch → 25.4 mm exactly.
+    expect(parseLength('1', 'in')).toBeCloseTo(25.4, 6);
+    expect(parseLength('0.5', 'in')).toBeCloseTo(12.7, 6);
+  });
+
+  test('comma → dot normalisation (accepts European decimal)', () => {
+    expect(parseLength('10,5', 'mm')).toBe(10.5);
+    expect(parseLength('0,5', 'in')).toBeCloseTo(12.7, 6);
+  });
+
+  test('leading / trailing whitespace is trimmed', () => {
+    expect(parseLength('  10.0  ', 'mm')).toBe(10);
+  });
+});
+
+describe('formatLength / parseLength round-trip', () => {
+  test('mm → mm round-trip is exact within 1 decimal of precision', () => {
+    const values = [0, 0.5, 1, 6, 10, 15, 25, 100, 1234.5];
+    for (const v of values) {
+      const s = formatLength(v, 'mm');
+      const parsed = parseLength(s, 'mm');
+      expect(parsed).toBeCloseTo(v, 1);
+    }
+  });
+
+  test('mm → in → mm round-trip preserves value within 3-decimal-inch precision', () => {
+    // 3-decimal inches resolves 0.001" = 0.0254 mm. Round-tripping an mm
+    // value through formatLength(in) → parseLength(in) can therefore drift
+    // by up to ±0.0127 mm (half the inch ULP). We assert inside that bound.
+    const INCH_ULP_MM = 25.4 / 1000;
+    const MAX_DRIFT_MM = INCH_ULP_MM / 2 + 1e-9;
+    const values = [6, 10, 15, 25, 1, 1.5, 5];
+    for (const mm of values) {
+      const displayed = formatLength(mm, 'in');
+      const roundTripped = parseLength(displayed, 'in');
+      expect(Math.abs(roundTripped - mm)).toBeLessThanOrEqual(MAX_DRIFT_MM);
+    }
+  });
+
+  test('1 in round-trip is exactly 25.4 mm within tolerance', () => {
+    // The assertion the issue spec calls out by name:
+    //   formatLength(25.4, 'in') === "1.000"
+    //   parseLength("1", 'in') === 25.4 (1e-4 tolerance)
+    expect(formatLength(25.4, 'in')).toBe('1.000');
+    expect(Math.abs(parseLength('1', 'in') - 25.4)).toBeLessThan(
+      LENGTH_ROUND_TRIP_ABS_TOL_MM,
+    );
+  });
+});

--- a/tests/renderer/state/parameters.test.ts
+++ b/tests/renderer/state/parameters.test.ts
@@ -1,0 +1,239 @@
+// tests/renderer/state/parameters.test.ts
+//
+// Unit tests for the parameter store. Covers:
+//
+//   1. Defaults match the research doc (docs/research/molding-techniques.md §6,
+//      APPROVED 2026-04-18) — guards against a drift where the table in
+//      issue #31 is silently re-applied.
+//   2. `update()` emits the new snapshot to subscribers; repeated updates
+//      with unchanged values are no-ops.
+//   3. `reset()` restores every field to the default and emits.
+//   4. `subscribe()` returns an unsubscribe function that actually detaches.
+//   5. `isAtDefaults()` tracks the edit state used by the "Reset" button.
+//   6. The snapshot is frozen — mutating it does not change the store.
+
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  DEFAULT_PARAMETERS,
+  KEY_STYLE_OPTIONS,
+  NUMERIC_CONSTRAINTS,
+  SIDE_COUNT_OPTIONS,
+  createParametersStore,
+  type MoldParameters,
+} from '@/renderer/state/parameters';
+
+describe('DEFAULT_PARAMETERS', () => {
+  test('matches molding-techniques.md §6 recommendation', () => {
+    expect(DEFAULT_PARAMETERS).toEqual({
+      wallThickness_mm: 10,
+      baseThickness_mm: 5,
+      sideCount: 4,
+      sprueDiameter_mm: 5,
+      ventDiameter_mm: 1.5,
+      ventCount: 2,
+      registrationKeyStyle: 'asymmetric-hemi',
+      draftAngle_deg: 0,
+    });
+  });
+
+  test('is frozen (mutations rejected)', () => {
+    expect(Object.isFrozen(DEFAULT_PARAMETERS)).toBe(true);
+  });
+});
+
+describe('NUMERIC_CONSTRAINTS', () => {
+  test('wallThickness range 6–25 mm per research doc', () => {
+    expect(NUMERIC_CONSTRAINTS.wallThickness_mm).toMatchObject({
+      min: 6,
+      max: 25,
+      integer: false,
+    });
+  });
+
+  test('baseThickness range 2–15 mm per research doc', () => {
+    expect(NUMERIC_CONSTRAINTS.baseThickness_mm).toMatchObject({
+      min: 2,
+      max: 15,
+      integer: false,
+    });
+  });
+
+  test('sprueDiameter range 3–8 mm per research doc', () => {
+    expect(NUMERIC_CONSTRAINTS.sprueDiameter_mm).toMatchObject({
+      min: 3,
+      max: 8,
+      integer: false,
+    });
+  });
+
+  test('ventDiameter range 1–3 mm per research doc', () => {
+    expect(NUMERIC_CONSTRAINTS.ventDiameter_mm).toMatchObject({
+      min: 1,
+      max: 3,
+      integer: false,
+    });
+  });
+
+  test('ventCount is integer, range 0–8 (research doc silent; issue default)', () => {
+    expect(NUMERIC_CONSTRAINTS.ventCount).toMatchObject({
+      min: 0,
+      max: 8,
+      integer: true,
+    });
+  });
+
+  test('draftAngle range 0–3° per research doc', () => {
+    expect(NUMERIC_CONSTRAINTS.draftAngle_deg).toMatchObject({
+      min: 0,
+      max: 3,
+      integer: false,
+    });
+  });
+
+  test('every default falls inside its own range', () => {
+    // Guards against a future edit where the default drifts outside
+    // the clamp range, which would make `reset()` look broken.
+    (Object.keys(NUMERIC_CONSTRAINTS) as Array<keyof typeof NUMERIC_CONSTRAINTS>).forEach((k) => {
+      const c = NUMERIC_CONSTRAINTS[k];
+      const v = DEFAULT_PARAMETERS[k];
+      expect(v).toBeGreaterThanOrEqual(c.min);
+      expect(v).toBeLessThanOrEqual(c.max);
+    });
+  });
+});
+
+describe('SIDE_COUNT_OPTIONS / KEY_STYLE_OPTIONS', () => {
+  test('side count options are exactly 2, 3, 4', () => {
+    expect([...SIDE_COUNT_OPTIONS]).toEqual([2, 3, 4]);
+  });
+
+  test('key style options are the three locked enum values', () => {
+    expect([...KEY_STYLE_OPTIONS]).toEqual([
+      'asymmetric-hemi',
+      'cone',
+      'keyhole',
+    ]);
+  });
+});
+
+describe('createParametersStore', () => {
+  test('get() returns defaults for a fresh store', () => {
+    const store = createParametersStore();
+    expect(store.get()).toEqual(DEFAULT_PARAMETERS);
+    expect(store.isAtDefaults()).toBe(true);
+  });
+
+  test('initial overrides merge shallowly over defaults', () => {
+    const store = createParametersStore({
+      wallThickness_mm: 8,
+      sideCount: 2,
+    });
+    expect(store.get().wallThickness_mm).toBe(8);
+    expect(store.get().sideCount).toBe(2);
+    expect(store.get().baseThickness_mm).toBe(
+      DEFAULT_PARAMETERS.baseThickness_mm,
+    );
+    expect(store.isAtDefaults()).toBe(false);
+  });
+
+  test('update() triggers subscriber with new snapshot', () => {
+    const store = createParametersStore();
+    const spy = vi.fn((_p: Readonly<MoldParameters>) => undefined);
+    store.subscribe(spy);
+
+    store.update({ wallThickness_mm: 7 });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const call = spy.mock.calls[0];
+    expect(call).toBeDefined();
+    const snapshot = call![0]!;
+    expect(snapshot.wallThickness_mm).toBe(7);
+    expect(store.get().wallThickness_mm).toBe(7);
+    expect(store.isAtDefaults()).toBe(false);
+  });
+
+  test('update() with unchanged values is a no-op (no listener fire)', () => {
+    const store = createParametersStore();
+    const spy = vi.fn();
+    store.subscribe(spy);
+
+    // wallThickness defaults to 10; setting it to 10 is a no-op.
+    store.update({ wallThickness_mm: DEFAULT_PARAMETERS.wallThickness_mm });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test('reset() restores every field to defaults and emits', () => {
+    const store = createParametersStore({
+      wallThickness_mm: 7,
+      sideCount: 2,
+      draftAngle_deg: 3,
+    });
+    expect(store.isAtDefaults()).toBe(false);
+
+    const spy = vi.fn();
+    store.subscribe(spy);
+
+    store.reset();
+
+    expect(store.get()).toEqual(DEFAULT_PARAMETERS);
+    expect(store.isAtDefaults()).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test('reset() on an at-defaults store is a no-op (no listener fire)', () => {
+    const store = createParametersStore();
+    const spy = vi.fn();
+    store.subscribe(spy);
+    store.reset();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test('subscribe() returns an unsubscribe that actually detaches', () => {
+    const store = createParametersStore();
+    const spy = vi.fn();
+    const unsubscribe = store.subscribe(spy);
+
+    store.update({ wallThickness_mm: 12 });
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    store.update({ wallThickness_mm: 14 });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test('the snapshot returned by get() is frozen', () => {
+    const store = createParametersStore();
+    const snap = store.get();
+    expect(Object.isFrozen(snap)).toBe(true);
+    // Attempting to mutate throws in strict mode (Vitest runs ESM strict).
+    expect(() => {
+      // @ts-expect-error — intentionally testing the freeze contract.
+      snap.wallThickness_mm = 42;
+    }).toThrow();
+    // State itself is unchanged.
+    expect(store.get().wallThickness_mm).toBe(
+      DEFAULT_PARAMETERS.wallThickness_mm,
+    );
+  });
+
+  test('a throwing subscriber does not break other subscribers', () => {
+    const store = createParametersStore();
+    const bad = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const good = vi.fn();
+    // Suppress the console.error surface while we exercise the bad listener.
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+      /* swallow */
+    });
+    store.subscribe(bad);
+    store.subscribe(good);
+
+    store.update({ wallThickness_mm: 11 });
+
+    expect(bad).toHaveBeenCalledTimes(1);
+    expect(good).toHaveBeenCalledTimes(1);
+    errSpy.mockRestore();
+  });
+});

--- a/tests/renderer/ui/parameters/panel.test.ts
+++ b/tests/renderer/ui/parameters/panel.test.ts
@@ -1,0 +1,396 @@
+// tests/renderer/ui/parameters/panel.test.ts
+//
+// @vitest-environment happy-dom
+//
+// DOM-level tests for the right-sidebar parameter panel. Uses happy-dom
+// (a lightweight DOM implementation for Vitest) — a devDependency, not a
+// runtime dep. Runtime behaviour in production is Chromium-in-Electron;
+// happy-dom is the standard Vitest choice for UI assertions that don't
+// need a real browser.
+//
+// Coverage:
+//   1. Renders one row per field (8 rows + a reset button).
+//   2. The reset button disables when all values equal defaults, and
+//      re-enables after any change.
+//   3. Out-of-range input surfaces the "Out of range" error live.
+//   4. Blur clamps the value back into [min, max] and clears the error.
+//   5. Flipping the units-changed event re-renders length fields in the
+//      new unit without mutating the store (internal mm value unchanged).
+//   6. Every visible string goes through i18n (no hardcoded English on the
+//      factories' output — verified by checking that the rendered labels
+//      equal the values we set on the i18n resource bundle).
+
+import i18next from 'i18next';
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { initI18n, setUnitSystem } from '@/renderer/i18n';
+import {
+  DEFAULT_PARAMETERS,
+  createParametersStore,
+} from '@/renderer/state/parameters';
+import { mountParameterPanel } from '@/renderer/ui/parameters/panel';
+
+function mount(): {
+  container: HTMLElement;
+  store: ReturnType<typeof createParametersStore>;
+  panel: ReturnType<typeof mountParameterPanel>;
+} {
+  const container = document.createElement('aside');
+  container.id = 'sidebar';
+  document.body.appendChild(container);
+  const store = createParametersStore();
+  const panel = mountParameterPanel(container, store);
+  return { container, store, panel };
+}
+
+beforeEach(() => {
+  // happy-dom carries state between tests — scrub the document + reset i18n /
+  // persisted units so every test starts from a clean slate.
+  document.body.innerHTML = '';
+  try {
+    window.localStorage.removeItem('units');
+  } catch {
+    /* ignore */
+  }
+  // i18next is initialised once; if a previous test set a non-default unit,
+  // reset it explicitly.
+  setUnitSystem('mm');
+  initI18n();
+});
+
+describe('parameter panel — rendering', () => {
+  test('renders one field per parameter + title + reset button', () => {
+    const { container } = mount();
+
+    // Title
+    const title = container.querySelector('.sidebar__title');
+    expect(title).toBeTruthy();
+    expect(title?.textContent).toBe(i18next.t('parameters.title'));
+
+    // One field per parameter — 8 total (keyed by data-testid).
+    const fieldIds = [
+      'wallThickness',
+      'baseThickness',
+      'sideCount',
+      'sprueDiameter',
+      'ventDiameter',
+      'ventCount',
+      'registrationKeyStyle',
+      'draftAngle',
+    ];
+    for (const id of fieldIds) {
+      expect(
+        container.querySelector(`[data-testid="param-field-${id}"]`),
+      ).toBeTruthy();
+      expect(
+        container.querySelector(`[data-testid="param-input-${id}"]`),
+      ).toBeTruthy();
+    }
+
+    // Reset button
+    const reset = container.querySelector<HTMLButtonElement>(
+      '[data-testid="param-reset"]',
+    );
+    expect(reset).toBeTruthy();
+    expect(reset?.textContent).toBe(i18next.t('parameters.reset'));
+  });
+
+  test('default values populate every input', () => {
+    const { container } = mount();
+    const val = (id: string): string =>
+      (container.querySelector<HTMLInputElement | HTMLSelectElement>(
+        `[data-testid="param-input-${id}"]`,
+      ) as HTMLInputElement | HTMLSelectElement).value;
+
+    // Length defaults render with 1 decimal in mm.
+    expect(val('wallThickness')).toBe('10.0');
+    expect(val('baseThickness')).toBe('5.0');
+    expect(val('sprueDiameter')).toBe('5.0');
+    expect(val('ventDiameter')).toBe('1.5');
+
+    // Count (integer) renders plain.
+    expect(val('ventCount')).toBe('2');
+
+    // Angle (1 decimal).
+    expect(val('draftAngle')).toBe('0.0');
+
+    // Enum selects: stringified sideCount, enum key for keyStyle.
+    expect(val('sideCount')).toBe('4');
+    expect(val('registrationKeyStyle')).toBe('asymmetric-hemi');
+  });
+
+  test('tab order follows DOM order (keyboard reachability)', () => {
+    const { container } = mount();
+    const inputs = Array.from(
+      container.querySelectorAll<HTMLInputElement | HTMLSelectElement>(
+        '[data-testid^="param-input-"]',
+      ),
+    );
+    // Expected order mirrors the spec.
+    const expected = [
+      'wallThickness',
+      'baseThickness',
+      'sideCount',
+      'sprueDiameter',
+      'ventDiameter',
+      'ventCount',
+      'registrationKeyStyle',
+      'draftAngle',
+    ];
+    expect(inputs.map((el) => el.id)).toEqual(expected);
+  });
+});
+
+describe('parameter panel — reset button', () => {
+  test('disabled on mount (store starts at defaults)', () => {
+    const { container } = mount();
+    const reset = container.querySelector<HTMLButtonElement>(
+      '[data-testid="param-reset"]',
+    );
+    expect(reset?.disabled).toBe(true);
+  });
+
+  test('enables after a store mutation; disables again after reset', () => {
+    const { container, store } = mount();
+    const reset = container.querySelector<HTMLButtonElement>(
+      '[data-testid="param-reset"]',
+    )!;
+
+    store.update({ wallThickness_mm: 12 });
+    expect(reset.disabled).toBe(false);
+
+    store.reset();
+    expect(reset.disabled).toBe(true);
+  });
+
+  test('clicking reset restores every input value to the default', () => {
+    const { container, store } = mount();
+    store.update({
+      wallThickness_mm: 15,
+      baseThickness_mm: 10,
+      sideCount: 2,
+    });
+
+    const reset = container.querySelector<HTMLButtonElement>(
+      '[data-testid="param-reset"]',
+    )!;
+    reset.click();
+
+    expect(store.get()).toEqual(DEFAULT_PARAMETERS);
+    // The inputs should have been re-rendered from the store.
+    const wall = container.querySelector<HTMLInputElement>(
+      '[data-testid="param-input-wallThickness"]',
+    );
+    expect(wall?.value).toBe('10.0');
+  });
+});
+
+describe('parameter panel — validation + clamp-on-blur', () => {
+  test('typing out-of-range value surfaces the error message', () => {
+    const { container } = mount();
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-testid="param-input-wallThickness"]',
+    )!;
+
+    input.value = '99';
+    input.dispatchEvent(new Event('input'));
+
+    const err = container.querySelector<HTMLElement>(
+      '[data-testid="param-error-wallThickness"]',
+    )!;
+    expect(err.hidden).toBe(false);
+    expect(err.textContent).toBeTruthy();
+    // Interpolated with the mm range (min=6, max=25).
+    expect(err.textContent).toMatch(/6/);
+    expect(err.textContent).toMatch(/25/);
+
+    // aria-invalid flag is also set for a11y.
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+  });
+
+  test('blur clamps out-of-range value AND clears the error', () => {
+    const { container, store } = mount();
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-testid="param-input-wallThickness"]',
+    )!;
+
+    input.value = '100';
+    input.dispatchEvent(new Event('input'));
+    input.dispatchEvent(new Event('blur'));
+
+    // Clamped to max (25 mm).
+    expect(input.value).toBe('25.0');
+    expect(store.get().wallThickness_mm).toBe(25);
+
+    const err = container.querySelector<HTMLElement>(
+      '[data-testid="param-error-wallThickness"]',
+    )!;
+    expect(err.hidden).toBe(true);
+    expect(input.getAttribute('aria-invalid')).toBeNull();
+  });
+
+  test('blur with an in-range value commits without error', () => {
+    const { container, store } = mount();
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-testid="param-input-wallThickness"]',
+    )!;
+
+    input.value = '12';
+    input.dispatchEvent(new Event('input'));
+    input.dispatchEvent(new Event('blur'));
+
+    expect(input.value).toBe('12.0');
+    expect(store.get().wallThickness_mm).toBe(12);
+  });
+
+  test('blur on empty input clamps to min (sensible fallback)', () => {
+    const { container, store } = mount();
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-testid="param-input-wallThickness"]',
+    )!;
+
+    input.value = '';
+    input.dispatchEvent(new Event('blur'));
+
+    // NaN → clamped to min.
+    expect(input.value).toBe('6.0');
+    expect(store.get().wallThickness_mm).toBe(6);
+  });
+
+  test('ventCount rounds non-integer input on blur', () => {
+    const { container, store } = mount();
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-testid="param-input-ventCount"]',
+    )!;
+
+    input.value = '3.7';
+    input.dispatchEvent(new Event('blur'));
+
+    // `integer: true` → trunc during parse, then clamp into [0, 8].
+    expect(input.value).toBe('3');
+    expect(store.get().ventCount).toBe(3);
+  });
+});
+
+describe('parameter panel — units flip', () => {
+  test('flipping to inches redisplays length fields without losing precision', () => {
+    const { container, store } = mount();
+    const wall = container.querySelector<HTMLInputElement>(
+      '[data-testid="param-input-wallThickness"]',
+    )!;
+
+    // Default wallThickness_mm = 10 mm.
+    expect(wall.value).toBe('10.0');
+
+    // Flip to inches.
+    setUnitSystem('in');
+
+    // 10 mm / 25.4 mm·in⁻¹ ≈ 0.3937…, rendered with 3 decimals.
+    expect(wall.value).toBe('0.394');
+
+    // Internal mm value is unchanged.
+    expect(store.get().wallThickness_mm).toBe(10);
+
+    // Flip back.
+    setUnitSystem('mm');
+    expect(wall.value).toBe('10.0');
+    expect(store.get().wallThickness_mm).toBe(10);
+  });
+
+  test('typing an inches value commits the correct mm to the store', () => {
+    const { container, store } = mount();
+
+    setUnitSystem('in');
+    const wall = container.querySelector<HTMLInputElement>(
+      '[data-testid="param-input-wallThickness"]',
+    )!;
+
+    // User types 0.5 inches → 12.7 mm internal.
+    wall.value = '0.5';
+    wall.dispatchEvent(new Event('blur'));
+
+    expect(store.get().wallThickness_mm).toBeCloseTo(12.7, 3);
+  });
+
+  test('angle field is NOT unit-flipped (always degrees)', () => {
+    const { container } = mount();
+    const draft = container.querySelector<HTMLInputElement>(
+      '[data-testid="param-input-draftAngle"]',
+    )!;
+    const before = draft.value;
+
+    setUnitSystem('in');
+    expect(draft.value).toBe(before);
+
+    setUnitSystem('mm');
+    expect(draft.value).toBe(before);
+  });
+});
+
+describe('parameter panel — i18n', () => {
+  test('labels and reset button resolve through i18next (no hardcoded English)', () => {
+    const { container } = mount();
+
+    // Title, reset, and the label for each field match the en bundle.
+    expect(
+      container.querySelector('.sidebar__title')?.textContent,
+    ).toBe(i18next.t('parameters.title'));
+    expect(
+      container.querySelector('[data-testid="param-reset"]')?.textContent,
+    ).toBe(i18next.t('parameters.reset'));
+
+    // Per-field label pairs. We assert by matching the <label> to the i18n
+    // key. If an English string is hardcoded somewhere these would diverge.
+    const pairs: Array<[string, string]> = [
+      ['wallThickness', i18next.t('parameters.wall')],
+      ['baseThickness', i18next.t('parameters.base')],
+      ['sideCount', i18next.t('parameters.sideCount')],
+      ['sprueDiameter', i18next.t('parameters.sprue')],
+      ['ventDiameter', i18next.t('parameters.vent')],
+      ['ventCount', i18next.t('parameters.ventCount')],
+      ['registrationKeyStyle', i18next.t('parameters.keyStyle')],
+      ['draftAngle', i18next.t('parameters.draft')],
+    ];
+    for (const [id, expected] of pairs) {
+      const label = container.querySelector(
+        `[data-testid="param-field-${id}"] label`,
+      );
+      expect(label?.textContent).toBe(expected);
+    }
+  });
+
+  test('key-style select options render through i18n', () => {
+    const { container } = mount();
+    const select = container.querySelector<HTMLSelectElement>(
+      '[data-testid="param-input-registrationKeyStyle"]',
+    )!;
+    const options = Array.from(select.options).map((o) => o.textContent);
+    expect(options).toEqual([
+      i18next.t('parameters.keyStyleOptions.asymmetric-hemi'),
+      i18next.t('parameters.keyStyleOptions.cone'),
+      i18next.t('parameters.keyStyleOptions.keyhole'),
+    ]);
+  });
+
+  test('error message uses i18n key + interpolation (no literal "Out of range")', () => {
+    // If a developer hardcoded "Out of range" somewhere, this test fails
+    // when a future locale edit changes the key's format.
+    const { container } = mount();
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-testid="param-input-wallThickness"]',
+    )!;
+    input.value = '99';
+    input.dispatchEvent(new Event('input'));
+
+    const err = container.querySelector<HTMLElement>(
+      '[data-testid="param-error-wallThickness"]',
+    )!;
+    // Whatever the English text is, it must come from the i18n bundle and
+    // have the min/max interpolation applied. The bundle's canonical value
+    // is "Out of range ({{min}}–{{max}})" — after interpolation with the
+    // wallThickness constraints we expect a string ending in ")".
+    expect(err.textContent).toBe(
+      i18next.t('parameters.invalid', { min: '6.0', max: '25.0' }),
+    );
+  });
+});

--- a/tests/visual/sidebar-parameters.spec.ts
+++ b/tests/visual/sidebar-parameters.spec.ts
@@ -1,0 +1,80 @@
+// tests/visual/sidebar-parameters.spec.ts
+//
+// Visual regression: the right-sidebar parameter form at default state.
+// Captures the whole app window so the viewport + grid layout + sidebar
+// render together — this is the "user's first-launch experience" view.
+//
+// First-run behaviour: this spec will produce a new golden on its first
+// green CI run. Per ADR-003 §B (§"Visual-regression gating policy") the
+// visual-regression job is advisory for the first 2 weeks after first
+// green, so the missing-golden failure does not block PR merge. QA will
+// confirm the golden-candidate in CI before the diff is committed.
+
+import { expect, test, type Page } from '@playwright/test';
+
+const RENDERER_URL = 'http://localhost:5174/?test=1';
+
+async function openRenderer(page: Page): Promise<void> {
+  await page.clock.install({ time: new Date('2026-04-18T00:00:00Z') });
+  await page.addInitScript(() => {
+    (window as unknown as { api: Record<string, unknown> }).api = {
+      getVersion: () => Promise.resolve('0.0.0'),
+      openStl: () =>
+        Promise.resolve({ canceled: true, paths: [] as string[] }),
+      saveStl: () => Promise.resolve({ canceled: true }),
+    };
+    try {
+      window.localStorage.removeItem('units');
+    } catch {
+      /* ignore */
+    }
+  });
+  await page.goto(RENDERER_URL);
+  // Wait for the sidebar to be populated — the reset button is the
+  // last element mounted by `mountParameterPanel`.
+  await page.waitForSelector('[data-testid="param-reset"]', {
+    timeout: 10_000,
+  });
+  // Also wait for the topbar so the full window is deterministic.
+  await page.waitForFunction(
+    () =>
+      !!(
+        window as unknown as {
+          __testHooks?: { topbar?: unknown; parameters?: unknown };
+        }
+      ).__testHooks?.parameters,
+    undefined,
+    { timeout: 10_000 },
+  );
+  await page.clock.runFor(100);
+}
+
+test.describe('visual — sidebar parameters', () => {
+  test('default state: all 8 fields + reset disabled', async ({ page }) => {
+    await openRenderer(page);
+    await expect(page).toHaveScreenshot('sidebar-parameters-defaults.png', {
+      maxDiffPixelRatio: 0.01,
+      threshold: 0.15,
+      animations: 'disabled',
+      fullPage: false,
+    });
+  });
+
+  test('inches mode: length fields redisplay with 3 decimals', async ({
+    page,
+  }) => {
+    await openRenderer(page);
+    // Flip the topbar toggle.
+    await page.click('[data-testid="units-toggle-in"]');
+    await page.clock.runFor(50);
+    await expect(page).toHaveScreenshot(
+      'sidebar-parameters-inches.png',
+      {
+        maxDiffPixelRatio: 0.01,
+        threshold: 0.15,
+        animations: 'disabled',
+        fullPage: false,
+      },
+    );
+  });
+});


### PR DESCRIPTION
# Summary

Adds the right-sidebar mold-parameter form for Phase 3b (issue #31). No geometry is generated — this PR populates the state that Phase 3c will consume. All 8 parameters are editable, unit-aware for length fields, live-validated, clamp-on-blur, reset-to-defaults, and fully internationalised.

## Linked issue

Closes #31

## Defaults: research doc over issue-body table

The issue body table and `docs/research/molding-techniques.md §6` diverged on 6 of 8 numeric defaults. The issue's own instruction is:
> if a doc contradicts the table, the table is wrong.

Per that instruction (and my clarification comment on #31 flagging **Option A**), I took the research-doc numbers as authoritative:

| Key | Default | Range |
|---|---|---|
| `wallThickness_mm` | 10 | 6–25 |
| `baseThickness_mm` | 5 | 2–15 |
| `sideCount` | 4 | {2, 3, 4} |
| `sprueDiameter_mm` | 5 | 3–8 |
| `ventDiameter_mm` | 1.5 | 1–3 |
| `ventCount` | 2 | 0–8 (doc silent; issue default kept) |
| `registrationKeyStyle` | `asymmetric-hemi` | locked enum |
| `draftAngle_deg` | 0 | 0–3 |

If the lead prefers the issue-table numbers, they're a one-line edit in `src/renderer/state/parameters.ts` — no geometry has been wired to these yet.

## Acceptance criteria (from the issue)

- [x] Right sidebar visible on app launch with all 8 fields + "Reset to defaults" button.
- [x] All strings go through i18n; no hardcoded English in component files (grep-verified — only i18n keys + data-testid / css strings in the diff).
- [x] Changing mm ↔ inches on the topbar instantly redisplays length fields in the new unit, without losing precision (internal mm value unchanged).
- [x] Out-of-range input shows an inline error; clamp-on-blur to the nearest valid value.
- [x] "Reset to defaults" restores every field to the table above; button disables when already at defaults.
- [x] State is queryable: `window.__testHooks.parameters` (the "or equivalent" escape the issue permits) returns a `ParametersStore`; Phase 3c will wire the module-level `parametersStore` in `main.ts` directly.
- [x] Unit test: `parametersStore.update({ wallThickness_mm: 7 })` triggers subscriber with the new value; `.reset()` restores defaults.
- [x] Unit test: `formatLength(25.4, 'in') === "1.000"` and `parseLength("1", 'in') === 25.4` (1e-4 tolerance).
- [x] Unit test: parameter panel renders one row per field; error message appears when value out of range.
- [x] Playwright visual spec: full app screenshot includes the sidebar with default values. (New golden — will fail the advisory visual job on first run; CI generates the baseline for QA to sign off.)
- [x] Playwright E2E: type out-of-range, blur, observe clamped value + transient error message.
- [x] No new **runtime** dependency added. `happy-dom@^20` added to `devDependencies` only for Vitest UI tests — verified with `pnpm why happy-dom`.
- [x] Dark theme parity — sidebar uses the existing `--bg`, `--fg`, `--muted`, `--accent`, `--border` tokens. No new colour tokens introduced.
- [x] Tab-through reachability: inputs appear in DOM spec-order; focus ring (outline: 2px solid var(--accent)) on every field.

## What I did

- **New files**:
  - `src/renderer/state/parameters.ts` — `MoldParameters` type, frozen `DEFAULT_PARAMETERS`, `NUMERIC_CONSTRAINTS`, `createParametersStore()` observable.
  - `src/renderer/ui/parameters/field.ts` — `createNumberField` / `createSelectField` factories.
  - `src/renderer/ui/parameters/panel.ts` — mounts title + 8 fields + reset button; wires the store to the DOM and listens to `units-changed`.
  - `tests/renderer/state/parameters.test.ts` — 20 store unit tests.
  - `tests/renderer/length-formatters.test.ts` — 12 formatter unit tests.
  - `tests/renderer/ui/parameters/panel.test.ts` — 17 happy-dom panel tests.
  - `tests/e2e/parameters-clamp.spec.ts` — 3 Electron E2E specs.
  - `tests/visual/sidebar-parameters.spec.ts` — 2 visual-regression specs (new goldens).
- **Modified**:
  - `src/renderer/ui/formatters.ts` — added `formatLength` / `parseLength` with `MM_PER_IN` pinned.
  - `src/renderer/i18n/index.ts` — `t()` accepts an optional interpolation options bag.
  - `src/renderer/i18n/en.json` — new `parameters.*` section.
  - `src/renderer/index.html` — `<aside id="sidebar">` + grid layout (viewport 1fr / 280 px sidebar) + param-field / sidebar CSS.
  - `src/renderer/main.ts` — `mountParameters()` creates store, mounts panel, exposes test hook.
  - `package.json` + `pnpm-lock.yaml` — `happy-dom` devDep.

## Test results

- [x] `pnpm lint` — green
- [x] `pnpm typecheck` — green
- [x] `pnpm test` — green, 128 passed / 1 skipped (mini-figurine fixture-dependent)
- [ ] `pnpm test:e2e` — not run locally in the worktree (Electron runs only from the packaged app). Specs added; CI `windows-latest` will exercise them.
- [x] `pnpm build:renderer:test` — green, bundle transforms 30 modules
- [x] New unit tests added for changed behaviour (51 new tests total)
- [N/A] Canonical-SHA-256 STL snapshots — no geometry output changed.

## Screenshots / GIFs

_Not generated in the worktree (no WebGL available to the Electron-less renderer in the agent sandbox)._ The visual spec will render the first golden on CI under the `visual` Playwright project — QA should review the candidate PNG in `tests/__screenshots__/linux-ci/tests/visual/sidebar-parameters.spec.ts-snapshots/` and confirm the sidebar appearance matches the spec.

## Follow-ups (not in this PR)

- **First-run visual goldens.** The `sidebar-parameters-defaults.png` and `sidebar-parameters-inches.png` goldens will be generated by CI and need a human sign-off before the advisory visual job flips to required. Not blocking merge.
- **Phase 3c integration point.** `main.ts` holds a module-level `parametersStore` reference; Phase 3c just imports and reads from it. No public re-export yet — add one when the Generate button gets wired.
- **Keyboard: skip-to-viewport shortcut.** Explicitly deferred by the issue spec.
- **Light-theme parity.** Same — issue 3j.

## QA sign-off

- [ ] `qa-engineer` reviewed and approved
- [ ] Visual regression diff reviewed — first-run golden to be blessed in CI

## Checklist

- [x] Units: length fields are mm internally; inches is display-layer conversion
- [x] i18n: all user-visible strings routed through `i18next`, no hardcoded English
- [x] Secrets: no new credentials, tokens, or private keys in the diff
- [x] New env vars documented in `.env.example` — N/A (no new env vars)
- [x] `docs/status.md` — not updated; Phase 3b is in-flight, not a milestone close. Lead owns the log.
- [x] CLAUDE.md still accurate (no decisions that contradict it)

## Agent attribution

Primary author: `frontend-dev` (worktree `agent-a878fc22`)
Reviewed by: `qa-engineer` (pending)