### PR TITLE
feat(viewer): pick a face to lay flat on the bed

### DIFF
--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -29,5 +29,11 @@
     "draft": "Draft angle",
     "reset": "Reset to defaults",
     "invalid": "Out of range ({{min}}–{{max}})"
+  },
+  "layFlat": {
+    "toggle": "Place on face",
+    "toggleHint": "Click a face on the mesh to lay it flat on the print bed (Esc to cancel)",
+    "reset": "Reset orientation",
+    "resetHint": "Restore the mesh to its original STL orientation"
   }
 }

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -120,6 +120,16 @@
       .units-toggle button:hover:not(.is-active) {
         color: var(--fg);
       }
+      .place-on-face {
+        display: inline-flex;
+        gap: 8px;
+      }
+      .place-on-face__toggle[aria-pressed='true'],
+      .place-on-face__toggle.is-active {
+        background: var(--accent);
+        color: #0b0d10;
+        border-color: var(--accent);
+      }
       /* ---- Body layout: viewport + sidebar grid -------------------------- */
       #body {
         flex: 1 1 auto;

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -11,6 +11,7 @@
  * tsconfig include).
  */
 
+import { LAY_FLAT_ACTIVE_EVENT } from './scene/layFlatController';
 import { mount, type MountedViewport } from './scene/viewport';
 import { initI18n } from './i18n';
 import {
@@ -22,11 +23,16 @@ import {
   type ParameterPanelApi,
 } from './ui/parameters/panel';
 import { mountTopbar, type TopbarApi } from './ui/topbar';
+import {
+  mountPlaceOnFaceToggle,
+  type PlaceOnFaceToggleApi,
+} from './ui/placeOnFaceToggle';
 
 let topbar: TopbarApi | null = null;
 let viewport: MountedViewport | null = null;
 let parametersStore: ParametersStore | null = null;
 let parameterPanel: ParameterPanelApi | null = null;
+let placeOnFace: PlaceOnFaceToggleApi | null = null;
 
 async function hydrateVersion(): Promise<void> {
   // The topbar owns the `[data-testid="app-version"]` element now; keep
@@ -50,6 +56,34 @@ function mountUi(): void {
   }
   topbar = mountTopbar(header);
 
+  // Mount the "Place on face" + "Reset orientation" buttons inside the
+  // topbar center slot (next to Open STL). The topbar builds that slot
+  // as a flex row, so appending here flows naturally.
+  const center = header.querySelector<HTMLElement>('.topbar__center');
+  if (center) {
+    placeOnFace = mountPlaceOnFaceToggle(center, {
+      onToggle(active) {
+        if (!viewport) return;
+        if (active) viewport.enableFacePicking();
+        else viewport.disableFacePicking();
+      },
+      onReset() {
+        if (!viewport) return;
+        viewport.resetOrientation();
+      },
+    });
+
+    // Mirror viewport-side state transitions (auto-exit-on-commit,
+    // Escape-key exit) back into the toggle button so its pressed state
+    // never drifts from the controller's truth.
+    document.addEventListener(LAY_FLAT_ACTIVE_EVENT, (ev) => {
+      const detail = (ev as CustomEvent<boolean>).detail;
+      if (typeof detail === 'boolean' && placeOnFace) {
+        placeOnFace.setActive(detail);
+      }
+    });
+  }
+
   // Expose on the test-hook surface so visual specs can drive the UI
   // deterministically (set a known volume, flip units) without clicking.
   if (process.env.NODE_ENV === 'test') {
@@ -58,6 +92,7 @@ function mountUi(): void {
     };
     const hooks = w.__testHooks ?? {};
     hooks['topbar'] = topbar;
+    if (placeOnFace) hooks['placeOnFace'] = placeOnFace;
     w.__testHooks = hooks;
   }
 }
@@ -153,6 +188,13 @@ async function handleOpenStl(button: HTMLButtonElement): Promise<void> {
     const result = await viewport.setMaster(response.buffer);
     if (topbar) {
       topbar.setVolume(result.volume_mm3);
+    }
+    // Enable the lay-flat controls now that a master is in the scene.
+    // `setMaster` resets the master group to identity rotation, so the
+    // toggle must read "not active" regardless of its previous state.
+    if (placeOnFace) {
+      placeOnFace.setEnabled(true);
+      placeOnFace.setActive(false);
     }
   } catch (err) {
     console.error('[open-stl] unexpected error during load:', err);

--- a/src/renderer/scene/layFlat.ts
+++ b/src/renderer/scene/layFlat.ts
@@ -1,0 +1,147 @@
+// src/renderer/scene/layFlat.ts
+//
+// Pure math + scene-graph helpers for the "Place on face" (lay-flat)
+// interaction. This module deliberately owns zero rendering state,
+// zero pointer bookkeeping, and zero DOM bindings — the controller in
+// `layFlatController.ts` consumes these primitives.
+//
+// The critical invariant (locked by PR #29, reinforced by issue #32):
+//
+//   Viewport-level transforms mutate the Master GROUP only. We NEVER
+//   touch `BufferGeometry.attributes.position` or the paired `Manifold`.
+//   Downstream booleans / offsets / STL export therefore keep the user's
+//   original STL-faithful coordinates, regardless of how the user has
+//   rotated or re-centered the mesh for display.
+//
+// Two responsibilities:
+//
+//   1. `quaternionToAlignFaceDown(worldNormal)` — compute the rotation
+//      that maps a given (world-space) face normal to `(0, -1, 0)`, i.e.
+//      the face pointing at the print bed.
+//   2. `recenterGroup(group, mesh)` — given a Master group whose
+//      quaternion may have been composed with lay-flat rotations,
+//      re-derive the world-space AABB of its child mesh and translate
+//      the group so the mesh sits on Y=0 (lowest point) and centered
+//      on X=0/Z=0. This is the same contract the original `setMaster`
+//      auto-center pass satisfied (issue #25), now applicable on every
+//      rotation tick.
+//
+// `resetOrientation(group, mesh)` is a thin convenience: snap the
+// quaternion back to identity and re-apply recentering. The caller is
+// responsible for re-framing the camera afterwards (see viewport.ts).
+
+import { Box3, Quaternion, Vector3, type Mesh, type Object3D } from 'three';
+
+/**
+ * Compute the quaternion that rotates `worldNormal` to align with the
+ * downward world axis `(0, -1, 0)`. This is what "lay this face on the
+ * bed" means geometrically.
+ *
+ * Edge case — normal already points down:
+ *   `setFromUnitVectors((0,-1,0), (0,-1,0))` returns an identity
+ *   quaternion (dot = 1). No rotation applied. Test asserts this.
+ *
+ * Edge case — normal points up (opposite to target):
+ *   `setFromUnitVectors` picks a stable axis perpendicular to the input
+ *   (it tries X first, falls back to Y), so the 180° flip is well-defined
+ *   around X-axis for a `(0,1,0) → (0,-1,0)` input. Either X-axis or
+ *   Z-axis flip is acceptable — the face ends up down either way. Test
+ *   pins the behaviour regardless of which axis Three picks.
+ *
+ * The input does not need to be pre-normalised; we normalise defensively.
+ */
+export function quaternionToAlignFaceDown(worldNormal: Vector3): Quaternion {
+  const from = worldNormal.clone().normalize();
+  const to = new Vector3(0, -1, 0);
+  return new Quaternion().setFromUnitVectors(from, to);
+}
+
+/**
+ * Translate `group` so that the world-space AABB of its `mesh` child
+ * satisfies the auto-center-on-bed contract:
+ *   - mesh's bbox.min.y === 0  (lowest face sits on the print bed)
+ *   - mesh's bbox.center.x === 0 (centered on world X)
+ *   - mesh's bbox.center.z === 0 (centered on world Z)
+ *
+ * This is the same math `setMaster` runs on load, extracted here so the
+ * lay-flat controller can re-apply it after rotating the group (which
+ * in general leaves the mesh floating above / below / off-center
+ * relative to the bed).
+ *
+ * Implementation notes:
+ *
+ *   - We reset `group.position` to zero FIRST, then `updateMatrixWorld`,
+ *     then compute the world-space bbox. This gives us the bbox of the
+ *     rotation-only transform — any previous translation would otherwise
+ *     contaminate the result.
+ *   - `Box3.setFromObject(mesh)` walks the child's geometry and transforms
+ *     its local bounding sphere / AABB into world space. That's exactly
+ *     what we need after a quaternion mutation: the vertex buffer is
+ *     untouched, but the world-space footprint has changed.
+ *   - Returns the offset applied (post-rotation, pre-translation) as a
+ *     fresh `Vector3` so callers can derive the world-space bbox without
+ *     a second scan.
+ */
+export function recenterGroup(group: Object3D, mesh: Mesh): Vector3 {
+  // Wipe the group's translation so the bbox below reflects only the
+  // current rotation. If we skipped this, a previous offset would shift
+  // the bbox and `offset` would accumulate over successive lay-flats.
+  group.position.set(0, 0, 0);
+  group.updateMatrixWorld(true);
+
+  // World-space bbox under the current rotation.
+  const worldBbox = new Box3().setFromObject(mesh);
+  const center = new Vector3();
+  worldBbox.getCenter(center);
+
+  const offset = new Vector3(-center.x, -worldBbox.min.y, -center.z);
+  group.position.set(offset.x, offset.y, offset.z);
+  group.updateMatrixWorld(true);
+
+  return offset;
+}
+
+/**
+ * Restore the Master group to its pre-lay-flat state: identity rotation,
+ * followed by an auto-center pass. Equivalent to "Reset orientation" in
+ * the UI. The returned offset is the same one `setMaster` would have
+ * applied on initial load — the STL-faithful vertex buffer guarantees
+ * the result is identical.
+ */
+export function resetOrientation(group: Object3D, mesh: Mesh): Vector3 {
+  group.quaternion.identity();
+  return recenterGroup(group, mesh);
+}
+
+/**
+ * Transform a mesh-LOCAL face normal into world space.
+ *
+ * `intersection.face.normal` from three-mesh-bvh is in the mesh's LOCAL
+ * frame (the untouched BufferGeometry coords). For the lay-flat math
+ * to work correctly after repeated rotations, we need the same normal
+ * expressed in WORLD frame — which means applying the mesh's world
+ * normal matrix (inverse-transpose of the world matrix's 3x3 upper
+ * block) to the local normal.
+ *
+ * For a pure-rotation + translation transform (which is what the Master
+ * group carries) the normal matrix equals the rotation part directly,
+ * so this is cheap. We still go through the full normal-matrix path
+ * because the scene-graph API makes no contract that the group's
+ * transform will stay rotation-only — e.g. a future mirror feature
+ * would introduce a reflection and the normal matrix would need to
+ * invert the sign.
+ */
+export function localNormalToWorld(mesh: Mesh, localNormal: Vector3): Vector3 {
+  // Ensure the mesh's world matrix is current before reading it. Callers
+  // that mutate `group.quaternion` AND immediately compute a normal need
+  // this or they get a stale normal matrix.
+  mesh.updateMatrixWorld(true);
+
+  const worldNormal = localNormal.clone();
+  // Extract the 3x3 rotation/scale/shear part of the world matrix and
+  // apply its inverse-transpose to the normal. Three.js provides
+  // `Vector3.transformDirection(matrix4)` which does exactly that and
+  // re-normalises — what we want here.
+  worldNormal.transformDirection(mesh.matrixWorld);
+  return worldNormal.normalize();
+}

--- a/src/renderer/scene/layFlat.ts
+++ b/src/renderer/scene/layFlat.ts
@@ -30,7 +30,7 @@
 // quaternion back to identity and re-apply recentering. The caller is
 // responsible for re-framing the camera afterwards (see viewport.ts).
 
-import { Box3, Quaternion, Vector3, type Mesh, type Object3D } from 'three';
+import { Box3, Matrix3, Quaternion, Vector3, type Mesh, type Object3D } from 'three';
 
 /**
  * Compute the quaternion that rotates `worldNormal` to align with the
@@ -74,10 +74,18 @@ export function quaternionToAlignFaceDown(worldNormal: Vector3): Quaternion {
  *     then compute the world-space bbox. This gives us the bbox of the
  *     rotation-only transform — any previous translation would otherwise
  *     contaminate the result.
- *   - `Box3.setFromObject(mesh)` walks the child's geometry and transforms
- *     its local bounding sphere / AABB into world space. That's exactly
- *     what we need after a quaternion mutation: the vertex buffer is
- *     untouched, but the world-space footprint has changed.
+ *   - We walk the mesh's vertex buffer and transform each vertex by the
+ *     mesh's `matrixWorld` to compute a **tight** world-space AABB.
+ *     `Box3.setFromObject(mesh)` (without `precise=true`) would instead
+ *     copy the geometry's local AABB and transform its 8 corners — which
+ *     for an arbitrary rotation over-estimates the bbox, leaving
+ *     `min.y` lower than the true minimum of the rotated vertex set. On
+ *     the mini-figurine fixture (~70 mm tall, organic), that conservative
+ *     path puts the mesh floating ~16 mm above the bed after lay-flat
+ *     instead of resting on Y=0 — the blocker on PR #34's first round.
+ *     We intentionally avoid `Box3.setFromObject(mesh, true)` (the
+ *     `precise` flag) because the per-vertex walk here is simpler and
+ *     gives the same result without relying on that opt-in flag.
  *   - Returns the offset applied (post-rotation, pre-translation) as a
  *     fresh `Vector3` so callers can derive the world-space bbox without
  *     a second scan.
@@ -89,8 +97,10 @@ export function recenterGroup(group: Object3D, mesh: Mesh): Vector3 {
   group.position.set(0, 0, 0);
   group.updateMatrixWorld(true);
 
-  // World-space bbox under the current rotation.
-  const worldBbox = new Box3().setFromObject(mesh);
+  // Tight world-space bbox under the current rotation — vertex walk,
+  // not the conservative corner-transform path `Box3.setFromObject`
+  // uses by default.
+  const worldBbox = computeWorldBoxTight(mesh);
   const center = new Vector3();
   worldBbox.getCenter(center);
 
@@ -99,6 +109,42 @@ export function recenterGroup(group: Object3D, mesh: Mesh): Vector3 {
   group.updateMatrixWorld(true);
 
   return offset;
+}
+
+/**
+ * Compute the tight world-space AABB of a mesh by walking its position
+ * buffer and transforming each vertex through `mesh.matrixWorld`.
+ *
+ * This is what `Box3.setFromObject(mesh, true)` (the `precise` flag)
+ * does internally, but we implement it here so we don't rely on callers
+ * remembering to set that flag — `recenterGroup` needs a tight bbox
+ * or the mesh ends up floating after lay-flat (see comment in
+ * `recenterGroup`).
+ *
+ * Returns an empty `Box3` if the mesh has no geometry / no position
+ * attribute — callers should be tolerant of that shape (none of the
+ * current call sites hit it).
+ */
+export function computeWorldBoxTight(mesh: Mesh): Box3 {
+  const box = new Box3();
+  const geometry = mesh.geometry;
+  if (!geometry) return box;
+  const positionAttribute = geometry.getAttribute('position');
+  if (!positionAttribute) return box;
+
+  // Ensure the world matrix reflects any pending transform changes. We
+  // update the ancestor chain (not just the mesh) because the mesh's
+  // matrixWorld is the product of group.matrixWorld × mesh.matrixLocal.
+  mesh.updateWorldMatrix(true, false);
+
+  const v = new Vector3();
+  const count = positionAttribute.count;
+  for (let i = 0; i < count; i++) {
+    v.fromBufferAttribute(positionAttribute, i);
+    v.applyMatrix4(mesh.matrixWorld);
+    box.expandByPoint(v);
+  }
+  return box;
 }
 
 /**
@@ -123,13 +169,20 @@ export function resetOrientation(group: Object3D, mesh: Mesh): Vector3 {
  * normal matrix (inverse-transpose of the world matrix's 3x3 upper
  * block) to the local normal.
  *
- * For a pure-rotation + translation transform (which is what the Master
- * group carries) the normal matrix equals the rotation part directly,
- * so this is cheap. We still go through the full normal-matrix path
- * because the scene-graph API makes no contract that the group's
- * transform will stay rotation-only — e.g. a future mirror feature
- * would introduce a reflection and the normal matrix would need to
- * invert the sign.
+ * We use `Matrix3.getNormalMatrix(matrix4)`, which gives the true
+ * inverse-transpose. The naive alternative — `Vector3.transformDirection`
+ * — only re-applies the world matrix's 3x3 block and re-normalises. That
+ * is mathematically correct for rotations (orthonormal matrices are
+ * self-inverse-transpose modulo sign) and for uniform scale, but gives
+ * the wrong answer under non-uniform scale: a local normal `(1, 1, 0)/√2`
+ * on a mesh scaled `(2, 1, 0.5)` should transform to `(1, 2, 0)/√5`
+ * via the normal matrix, but `transformDirection` yields `(2, 1, 0)/√5`.
+ *
+ * The Master group today only carries rotation + translation, so both
+ * paths produce the same result in production. We still use the full
+ * normal-matrix path so v2 additions (mirror, non-uniform display scale)
+ * don't silently regress. The non-uniform-scale regression test in
+ * `layFlat.test.ts` pins this invariant.
  */
 export function localNormalToWorld(mesh: Mesh, localNormal: Vector3): Vector3 {
   // Ensure the mesh's world matrix is current before reading it. Callers
@@ -137,11 +190,10 @@ export function localNormalToWorld(mesh: Mesh, localNormal: Vector3): Vector3 {
   // this or they get a stale normal matrix.
   mesh.updateMatrixWorld(true);
 
-  const worldNormal = localNormal.clone();
-  // Extract the 3x3 rotation/scale/shear part of the world matrix and
-  // apply its inverse-transpose to the normal. Three.js provides
-  // `Vector3.transformDirection(matrix4)` which does exactly that and
-  // re-normalises — what we want here.
-  worldNormal.transformDirection(mesh.matrixWorld);
+  // `getNormalMatrix` computes the inverse-transpose of the 3x3 upper-left
+  // block of the supplied 4x4. Mutating `normalMatrix` here is cheap — it
+  // sits on the stack frame for this call only.
+  const normalMatrix = new Matrix3().getNormalMatrix(mesh.matrixWorld);
+  const worldNormal = localNormal.clone().applyMatrix3(normalMatrix);
   return worldNormal.normalize();
 }

--- a/src/renderer/scene/layFlatController.ts
+++ b/src/renderer/scene/layFlatController.ts
@@ -1,0 +1,416 @@
+// src/renderer/scene/layFlatController.ts
+//
+// Orchestrator for the "Place on face" (lay-flat) interaction. Binds
+// pointer events on the canvas, manages the hover-highlight mesh + the
+// normal-overlay quad, and commits the rotation when the user clicks a
+// face.
+//
+// Shape of the state machine:
+//
+//   idle           — no listeners; widgets invisible.
+//   activating     — transitions handled inline in enable(); no state flag.
+//   active-hover   — listening for pointermove; hover widgets follow cursor.
+//   active-miss    — same listeners but cursor isn't over mesh; widgets off.
+//   committing     — one-shot: applies rotation, recenters, re-frames camera,
+//                    then auto-exits back to idle per the issue spec:
+//                    "picking mode auto-exits on commit".
+//
+// Escape key exits from any active sub-state. The viewport handle owns
+// the lifecycle so this module doesn't need to track it explicitly.
+//
+// Design constraints (issue #32):
+//
+//   - Group-level transform only. Never mutate BufferGeometry.
+//   - `group.quaternion.premultiply(q)` compose order so repeated lay-flats
+//     chain correctly.
+//   - Re-run auto-center (`recenterGroup`) after rotation so the mesh
+//     doesn't float above the bed.
+//   - Re-frame camera after commit.
+//
+// This module is purposefully renderer-thin: it allocates its hover/
+// overlay widgets lazily on enable, and disposes them on disable so
+// the scene graph stays quiet when the mode is off.
+
+import {
+  Box3,
+  BufferAttribute,
+  BufferGeometry,
+  DoubleSide,
+  Group,
+  LineBasicMaterial,
+  LineSegments,
+  Mesh,
+  MeshBasicMaterial,
+  type PerspectiveCamera,
+  type Scene,
+  Vector3,
+} from 'three';
+import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+
+import { frameToBox3 } from './camera';
+import { quaternionToAlignFaceDown, recenterGroup, resetOrientation } from './layFlat';
+import { pickFaceUnderPointer, type PickResult } from './picking';
+
+/** Accent blue matching the app's CSS `--accent` variable (`#4a9eff`). */
+const ACCENT_COLOR = 0x4a9eff;
+
+/** Widgets live under the scene's `userData.tag === 'widgets'` group. */
+const WIDGETS_GROUP_TAG = 'widgets';
+
+/** Tag applied to our group of lay-flat widgets so tests can find it. */
+export const LAY_FLAT_WIDGETS_TAG = 'lay-flat-widgets';
+
+/**
+ * Custom event fired on `document` whenever the lay-flat controller's active
+ * state changes. Consumers (e.g. the UI toggle button) listen so they can
+ * reflect the auto-exit-on-commit transition back into their own state
+ * without polling the viewport handle on every animation frame.
+ *
+ * Detail payload is the new `active` boolean.
+ */
+export const LAY_FLAT_ACTIVE_EVENT = 'lay-flat-active-changed';
+
+/** Dimensions for the flat normal-indicator quad, in mm. */
+const NORMAL_QUAD_SIZE_MM = 15;
+
+export interface LayFlatController {
+  /** Enter picking mode: attach listeners, show cursor as crosshair. */
+  enable(): void;
+  /** Exit picking mode: detach listeners, hide widgets. */
+  disable(): void;
+  /** Return the group to identity rotation and re-center + re-frame. */
+  reset(): void;
+  /** Whether picking mode is currently active. */
+  isActive(): boolean;
+  /** Tear down permanently — remove widget group from the scene. */
+  dispose(): void;
+}
+
+export interface LayFlatControllerOptions {
+  readonly scene: Scene;
+  readonly camera: PerspectiveCamera;
+  readonly controls: OrbitControls;
+  readonly canvas: HTMLCanvasElement;
+  /**
+   * Retrieve the current master mesh. Returns `null` if no master is loaded,
+   * in which case `enable()` becomes a no-op. We accept a getter (not a
+   * snapshot) because the master can be swapped while the controller is
+   * long-lived — viewport ownership outlives any single master.
+   */
+  readonly getMasterMesh: () => Mesh | null;
+}
+
+/**
+ * Create a controller bound to a viewport. No listeners are attached
+ * until `enable()` is called. The widgets group is lazily created on
+ * first enable and reused across enable/disable cycles.
+ */
+export function createLayFlatController(
+  options: LayFlatControllerOptions,
+): LayFlatController {
+  const { scene, camera, controls, canvas, getMasterMesh } = options;
+
+  let active = false;
+  let disposed = false;
+
+  // --- Widgets --------------------------------------------------------------
+
+  const widgetsRoot = findWidgetsGroup(scene);
+  const widgets = new Group();
+  widgets.userData['tag'] = LAY_FLAT_WIDGETS_TAG;
+  widgets.visible = false;
+  widgetsRoot.add(widgets);
+
+  // Triangle outline (LineSegments) that traces the picked triangle's edges.
+  // Three vertices → three edges → 6 position entries (3 segments × 2 verts).
+  const triOutlineGeom = new BufferGeometry();
+  triOutlineGeom.setAttribute(
+    'position',
+    new BufferAttribute(new Float32Array(18), 3),
+  );
+  const triOutlineMat = new LineBasicMaterial({
+    color: ACCENT_COLOR,
+    depthTest: false,
+    transparent: true,
+    opacity: 0.95,
+  });
+  const triOutline = new LineSegments(triOutlineGeom, triOutlineMat);
+  triOutline.renderOrder = 999;
+  widgets.add(triOutline);
+
+  // Flat overlay quad — 2-tri square in the picked face's plane, centered at
+  // the hit point. Renders translucent to suggest "this plane goes flat".
+  const quadGeom = new BufferGeometry();
+  quadGeom.setAttribute(
+    'position',
+    new BufferAttribute(new Float32Array(18), 3),
+  );
+  const quadMat = new MeshBasicMaterial({
+    color: ACCENT_COLOR,
+    transparent: true,
+    opacity: 0.22,
+    side: DoubleSide,
+    depthTest: false,
+    depthWrite: false,
+  });
+  const normalQuad = new Mesh(quadGeom, quadMat);
+  normalQuad.renderOrder = 998;
+  widgets.add(normalQuad);
+
+  function updateWidgets(pick: PickResult): void {
+    const mesh = getMasterMesh();
+    if (!mesh) return;
+
+    // --- Triangle outline: read the three vertex positions from the mesh's
+    //     BufferGeometry, transform them to world space, stuff into the
+    //     LineSegments buffer as 3 edges (a-b, b-c, c-a).
+    const positions = mesh.geometry.getAttribute('position');
+    const triIndex = pick.faceIndex;
+    // Non-indexed geometry: triangle t occupies vertex indices [3t, 3t+1, 3t+2].
+    // Our adapters always emit non-indexed meshes from `manifoldToBufferGeometry`.
+    const v0 = new Vector3().fromBufferAttribute(positions, triIndex * 3);
+    const v1 = new Vector3().fromBufferAttribute(positions, triIndex * 3 + 1);
+    const v2 = new Vector3().fromBufferAttribute(positions, triIndex * 3 + 2);
+    mesh.localToWorld(v0);
+    mesh.localToWorld(v1);
+    mesh.localToWorld(v2);
+
+    const outlineArr = triOutlineGeom.getAttribute('position')
+      .array as Float32Array;
+    // Edge 0-1
+    outlineArr[0] = v0.x;
+    outlineArr[1] = v0.y;
+    outlineArr[2] = v0.z;
+    outlineArr[3] = v1.x;
+    outlineArr[4] = v1.y;
+    outlineArr[5] = v1.z;
+    // Edge 1-2
+    outlineArr[6] = v1.x;
+    outlineArr[7] = v1.y;
+    outlineArr[8] = v1.z;
+    outlineArr[9] = v2.x;
+    outlineArr[10] = v2.y;
+    outlineArr[11] = v2.z;
+    // Edge 2-0
+    outlineArr[12] = v2.x;
+    outlineArr[13] = v2.y;
+    outlineArr[14] = v2.z;
+    outlineArr[15] = v0.x;
+    outlineArr[16] = v0.y;
+    outlineArr[17] = v0.z;
+    triOutlineGeom.getAttribute('position').needsUpdate = true;
+    triOutlineGeom.computeBoundingSphere();
+
+    // --- Normal indicator quad: build a 2-triangle square in the plane
+    //     perpendicular to the world normal, centered at the hit point.
+    //     Offset slightly along the normal so it doesn't z-fight the mesh.
+    const n = pick.worldNormal.clone().normalize();
+    // Pick an arbitrary basis perpendicular to n. Prefer world-X; fall back
+    // to world-Y if n is too close to X.
+    const ref = Math.abs(n.x) < 0.9 ? new Vector3(1, 0, 0) : new Vector3(0, 1, 0);
+    const u = new Vector3().crossVectors(n, ref).normalize().multiplyScalar(
+      NORMAL_QUAD_SIZE_MM / 2,
+    );
+    const v = new Vector3().crossVectors(n, u).normalize().multiplyScalar(
+      NORMAL_QUAD_SIZE_MM / 2,
+    );
+    const c = pick.point.clone().addScaledVector(n, 0.05);
+
+    const p0 = c.clone().sub(u).sub(v);
+    const p1 = c.clone().add(u).sub(v);
+    const p2 = c.clone().add(u).add(v);
+    const p3 = c.clone().sub(u).add(v);
+
+    const quadArr = quadGeom.getAttribute('position').array as Float32Array;
+    // Tri 0: p0, p1, p2
+    quadArr[0] = p0.x;
+    quadArr[1] = p0.y;
+    quadArr[2] = p0.z;
+    quadArr[3] = p1.x;
+    quadArr[4] = p1.y;
+    quadArr[5] = p1.z;
+    quadArr[6] = p2.x;
+    quadArr[7] = p2.y;
+    quadArr[8] = p2.z;
+    // Tri 1: p0, p2, p3
+    quadArr[9] = p0.x;
+    quadArr[10] = p0.y;
+    quadArr[11] = p0.z;
+    quadArr[12] = p2.x;
+    quadArr[13] = p2.y;
+    quadArr[14] = p2.z;
+    quadArr[15] = p3.x;
+    quadArr[16] = p3.y;
+    quadArr[17] = p3.z;
+    quadGeom.getAttribute('position').needsUpdate = true;
+    quadGeom.computeVertexNormals();
+    quadGeom.computeBoundingSphere();
+
+    widgets.visible = true;
+  }
+
+  function hideWidgets(): void {
+    widgets.visible = false;
+  }
+
+  // --- Pointer handlers -----------------------------------------------------
+
+  function onPointerMove(ev: PointerEvent): void {
+    if (!active) return;
+    const mesh = getMasterMesh();
+    if (!mesh) {
+      hideWidgets();
+      return;
+    }
+    const pick = pickFaceUnderPointer(ev, canvas, camera, mesh);
+    if (pick) {
+      updateWidgets(pick);
+    } else {
+      hideWidgets();
+    }
+  }
+
+  function onPointerLeave(): void {
+    if (!active) return;
+    hideWidgets();
+  }
+
+  function onClick(ev: PointerEvent): void {
+    if (!active) return;
+    // Only primary-button clicks commit. Right-drag is OrbitControls pan —
+    // we must not hijack it.
+    if (ev.button !== 0) return;
+
+    const mesh = getMasterMesh();
+    if (!mesh) return;
+
+    // Re-pick at the click position so the commit acts on whatever's under
+    // the cursor at the moment of click — not whatever pointermove last saw,
+    // which could be one frame behind. Feels tighter.
+    const pick = pickFaceUnderPointer(ev, canvas, camera, mesh);
+    if (!pick) return;
+
+    commit(pick, mesh);
+  }
+
+  function onKeyDown(ev: KeyboardEvent): void {
+    if (!active) return;
+    if (ev.key === 'Escape') {
+      disable();
+    }
+  }
+
+  // --- Commit + reset -------------------------------------------------------
+
+  function commit(pick: PickResult, mesh: Mesh): void {
+    const group = mesh.parent;
+    if (!group) return;
+
+    // Compose the lay-flat rotation onto the group. `premultiply` (not
+    // `multiply`) so chaining lay-flats behaves as "rotate in world frame":
+    //   final = q_layFlat · existing_rotation
+    // which matches the user's mental model of "pick a face now, whatever
+    // the current orientation is".
+    const q = quaternionToAlignFaceDown(pick.worldNormal);
+    group.quaternion.premultiply(q);
+
+    // Re-apply auto-center post-rotation. Without this the mesh floats off
+    // the bed after the rotation (its world-space AABB has shifted).
+    recenterGroup(group, mesh);
+
+    // Re-frame the camera to the NEW world-space AABB (issue AC: "after
+    // commit, re-frame to the new world AABB").
+    const worldBbox = new Box3().setFromObject(mesh);
+    frameToBox3(camera, controls, worldBbox);
+
+    // Belt-and-braces: re-normalise the quaternion post-compose to keep it
+    // a unit quaternion even after many chained lay-flats (numerical drift
+    // accumulates slowly but surely).
+    group.quaternion.normalize();
+
+    // Clean up hover widgets + auto-exit picking mode (issue AC: "picking
+    // mode auto-exits on commit").
+    disable();
+  }
+
+  function reset(): void {
+    const mesh = getMasterMesh();
+    if (!mesh) return;
+    const group = mesh.parent;
+    if (!group) return;
+
+    resetOrientation(group, mesh);
+    const worldBbox = new Box3().setFromObject(mesh);
+    frameToBox3(camera, controls, worldBbox);
+
+    // Reset does not force picking mode on or off — the user might want to
+    // reset while the toggle is active (to pick a different face cleanly)
+    // or while it is inactive (pure "undo"). Respect current state.
+  }
+
+  // --- Enable / disable / dispose -------------------------------------------
+
+  function emitActiveChanged(): void {
+    document.dispatchEvent(
+      new CustomEvent<boolean>(LAY_FLAT_ACTIVE_EVENT, { detail: active }),
+    );
+  }
+
+  function enable(): void {
+    if (disposed) return;
+    if (active) return;
+    const mesh = getMasterMesh();
+    if (!mesh) return;
+    active = true;
+    canvas.style.cursor = 'crosshair';
+    canvas.addEventListener('pointermove', onPointerMove);
+    canvas.addEventListener('pointerleave', onPointerLeave);
+    canvas.addEventListener('click', onClick);
+    window.addEventListener('keydown', onKeyDown);
+    emitActiveChanged();
+  }
+
+  function disable(): void {
+    if (!active) return;
+    active = false;
+    canvas.style.cursor = '';
+    canvas.removeEventListener('pointermove', onPointerMove);
+    canvas.removeEventListener('pointerleave', onPointerLeave);
+    canvas.removeEventListener('click', onClick);
+    window.removeEventListener('keydown', onKeyDown);
+    hideWidgets();
+    emitActiveChanged();
+  }
+
+  function dispose(): void {
+    disable();
+    disposed = true;
+    triOutlineGeom.dispose();
+    triOutlineMat.dispose();
+    quadGeom.dispose();
+    quadMat.dispose();
+    if (widgets.parent) widgets.parent.remove(widgets);
+  }
+
+  return {
+    enable,
+    disable,
+    reset,
+    isActive: () => active,
+    dispose,
+  };
+}
+
+/**
+ * Locate the scene's pre-built Widgets group (`tag: 'widgets'`) for
+ * attaching lay-flat overlays. Falls back to the scene itself if no such
+ * group exists — avoids crashing on a scene that was hand-built in a test.
+ */
+function findWidgetsGroup(scene: Scene): Scene | Group {
+  for (const child of scene.children) {
+    if (child.userData['tag'] === WIDGETS_GROUP_TAG && child instanceof Group) {
+      return child;
+    }
+  }
+  return scene;
+}

--- a/src/renderer/scene/layFlatController.ts
+++ b/src/renderer/scene/layFlatController.ts
@@ -32,7 +32,6 @@
 // the scene graph stays quiet when the mode is off.
 
 import {
-  Box3,
   BufferAttribute,
   BufferGeometry,
   DoubleSide,
@@ -48,7 +47,12 @@ import {
 import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 import { frameToBox3 } from './camera';
-import { quaternionToAlignFaceDown, recenterGroup, resetOrientation } from './layFlat';
+import {
+  computeWorldBoxTight,
+  quaternionToAlignFaceDown,
+  recenterGroup,
+  resetOrientation,
+} from './layFlat';
 import { pickFaceUnderPointer, type PickResult } from './picking';
 
 /** Accent blue matching the app's CSS `--accent` variable (`#4a9eff`). */
@@ -319,8 +323,11 @@ export function createLayFlatController(
     recenterGroup(group, mesh);
 
     // Re-frame the camera to the NEW world-space AABB (issue AC: "after
-    // commit, re-frame to the new world AABB").
-    const worldBbox = new Box3().setFromObject(mesh);
+    // commit, re-frame to the new world AABB"). Use the vertex-walk bbox
+    // — `Box3.setFromObject` without `precise=true` transforms the local
+    // AABB's 8 corners, which for an arbitrary rotation over-estimates
+    // the world bbox and would leave the camera framed to the wrong size.
+    const worldBbox = computeWorldBoxTight(mesh);
     frameToBox3(camera, controls, worldBbox);
 
     // Belt-and-braces: re-normalise the quaternion post-compose to keep it
@@ -340,7 +347,9 @@ export function createLayFlatController(
     if (!group) return;
 
     resetOrientation(group, mesh);
-    const worldBbox = new Box3().setFromObject(mesh);
+    // Tight vertex-walk bbox — see `commit()` for why we don't use
+    // `Box3.setFromObject`.
+    const worldBbox = computeWorldBoxTight(mesh);
     frameToBox3(camera, controls, worldBbox);
 
     // Reset does not force picking mode on or off — the user might want to

--- a/src/renderer/scene/master.ts
+++ b/src/renderer/scene/master.ts
@@ -34,6 +34,7 @@ import { Box3, Mesh, MeshStandardMaterial, Vector3, type Scene } from 'three';
 import { loadStl } from '@/geometry/loadStl';
 import { manifoldToBufferGeometry } from '@/geometry/adapters';
 import { meshVolume } from '@/geometry/volume';
+import { prepareMeshForPicking, releaseMeshPicking } from './picking';
 
 /**
  * Pre-existing master-group tag placed by `createScene()`. We look the group
@@ -82,6 +83,10 @@ function findMasterGroup(scene: Scene): Mesh['parent'] | null {
  * dance, and skipping it leaks WebGL memory on every reload.
  */
 function disposeMesh(mesh: Mesh): void {
+  // Release the three-mesh-bvh bounds tree first. `disposeBoundsTree` is a
+  // no-op when no tree was ever built, so this is safe to call on meshes
+  // loaded by earlier code paths that didn't install picking.
+  releaseMeshPicking(mesh);
   mesh.geometry.dispose();
   const mat = mesh.material;
   if (Array.isArray(mat)) {
@@ -196,12 +201,27 @@ export async function setMaster(scene: Scene, buffer: ArrayBuffer): Promise<Mast
     }
   }
 
+  // Reset rotation before adding the new mesh. A previous `setMaster` could
+  // have composed a lay-flat rotation onto the group via the Place-on-face
+  // UI (issue #32); without this line, a second Open STL would inherit the
+  // prior orientation — which is jarring and would fail the issue's AC
+  // ("Load second STL after a lay-flat rotation → new master loads at
+  // identity orientation, not inheriting stale quaternion").
+  group.quaternion.identity();
+
   const material = createMasterMaterial();
   const mesh = new Mesh(displayGeometry, material);
   mesh.userData['tag'] = MASTER_MESH_TAG;
   // No scale / rotation / translation — scene is mm-native and we never
   // apply renderer-layer scaling (locked convention in CLAUDE.md).
   group.add(mesh);
+
+  // Build the three-mesh-bvh bounds tree on the new geometry so face
+  // picking (issue #32) is O(log N). This must happen AFTER the mesh is
+  // parented (the bounds tree only needs the geometry, but we keep the
+  // ordering obvious) and BEFORE any picking / raycasting by sibling
+  // code. Matched by `releaseMeshPicking(mesh)` inside `disposeMesh`.
+  prepareMeshForPicking(mesh);
 
   // Mesh-local AABB (the raw geometry bounds, before any group transform).
   // This is the input to the auto-center calculation below.
@@ -219,24 +239,31 @@ export async function setMaster(scene: Scene, buffer: ArrayBuffer): Promise<Mast
   // stay STL-faithful so downstream mold-gen + STL export see the user's
   // original coordinates.
   //
+  // We use the mesh-local bbox directly (instead of going through
+  // `recenterGroup` → `Box3.setFromObject` as the lay-flat path does)
+  // because we just reset the group quaternion to identity above. On
+  // identity rotation the local bbox equals the world-space bbox
+  // bit-identically, and reading it directly avoids the float32 drift
+  // that per-vertex world-matrix multiplies introduce on fixtures with
+  // large coordinates (e.g. mini-figurine at Y≈1094 → ~1e-4 mm drift).
+  //
   // `.set()` is absolute (not additive), which means a second load fully
-  // replaces any previous offset — no accumulation across loads. This is
-  // asserted in the unit tests.
+  // replaces any previous offset — no accumulation across loads.
   const localCenter = new Vector3();
   localBbox.getCenter(localCenter);
   const offset = new Vector3(-localCenter.x, -localBbox.min.y, -localCenter.z);
   group.position.set(offset.x, offset.y, offset.z);
-  // Keep the group's world matrices current so subsequent calls that rely on
-  // `mesh.getWorldPosition(...)` etc. see the new transform without waiting
-  // for the next render tick.
+  // Keep the group's world matrices current so subsequent calls that rely
+  // on `mesh.getWorldPosition(...)` etc. see the new transform without
+  // waiting for the next render tick.
   group.updateMatrixWorld(true);
 
-  // World-space AABB. The mesh itself has identity transform, but the
+  // World-space AABB. The mesh has identity local transform, but the
   // group now carries the offset — apply it to the local bbox so callers
   // (notably `frameToBox3`) frame the camera around where the mesh
   // actually sits, not where the raw geometry would have sat. Framing the
   // mesh-local bbox on an off-origin master (e.g. mini-figurine at Y≈1094)
-  // would leave the origin grid + axes gizmo off-camera — see issue #25.
+  // would leave the origin grid + axes gizmo off-camera.
   const bbox = localBbox.clone().translate(offset);
 
   return { mesh, volume_mm3, bbox, offset };

--- a/src/renderer/scene/picking.ts
+++ b/src/renderer/scene/picking.ts
@@ -1,0 +1,204 @@
+// src/renderer/scene/picking.ts
+//
+// BVH-accelerated face picking for the Master mesh.
+//
+// `three-mesh-bvh` ships three monkey-patches that, once installed,
+// route all `Mesh.raycast` calls through a precomputed bounds tree.
+// ADR-002 locks `three-mesh-bvh` as the single interactive-picking
+// library; issue #32's BVH-setup reminder repeats the pattern.
+//
+// The patches are global and idempotent — we install them once at
+// module load. Calling `installAcceleratedRaycast()` more than once
+// is safe; the implementation short-circuits on subsequent calls.
+//
+// Per-mesh lifecycle:
+//
+//   `prepareMeshForPicking(mesh)`   — build the BVH (`computeBoundsTree`)
+//                                     on the mesh's geometry.
+//   `releaseMeshPicking(mesh)`      — dispose the BVH. Called from the
+//                                     master-teardown path in `master.ts`
+//                                     so a reloaded STL doesn't leak
+//                                     a stale tree.
+//
+// Picking:
+//
+//   `pickFaceUnderPointer(event, camera, mesh)` — projects the pointer
+//                                                 event into a world-
+//                                                 space ray, raycasts
+//                                                 against the BVH-backed
+//                                                 mesh, and returns the
+//                                                 hit + world-normal or
+//                                                 `null` if the cursor
+//                                                 missed. Works on either
+//                                                 a `PointerEvent` from
+//                                                 the canvas or a plain
+//                                                 `{clientX, clientY}`
+//                                                 shape (useful for tests
+//                                                 that dispatch synthetic
+//                                                 events).
+
+import {
+  BufferGeometry,
+  Mesh,
+  type PerspectiveCamera,
+  Raycaster,
+  Vector2,
+  type Vector3,
+} from 'three';
+import {
+  acceleratedRaycast,
+  computeBoundsTree,
+  disposeBoundsTree,
+} from 'three-mesh-bvh';
+
+import { localNormalToWorld } from './layFlat';
+
+/** Module-scope flag — patches are global and only safe to install once. */
+let patchesInstalled = false;
+
+/**
+ * Install the three `three-mesh-bvh` monkey-patches required for accelerated
+ * raycasting: `Mesh.raycast` + `BufferGeometry.{compute,dispose}BoundsTree`.
+ *
+ * Idempotent. Called automatically by `prepareMeshForPicking` — callers
+ * rarely need to invoke it directly, but it's exported for test setup.
+ */
+export function installAcceleratedRaycast(): void {
+  if (patchesInstalled) return;
+  // `any`-casts here because `three-mesh-bvh`'s typing augments prototypes
+  // but we install at runtime without module augmentation to keep the
+  // types simple. Safe: the cast target is the method slot we're patching.
+  (Mesh.prototype as unknown as { raycast: typeof acceleratedRaycast }).raycast =
+    acceleratedRaycast;
+  (
+    BufferGeometry.prototype as unknown as {
+      computeBoundsTree: typeof computeBoundsTree;
+    }
+  ).computeBoundsTree = computeBoundsTree;
+  (
+    BufferGeometry.prototype as unknown as {
+      disposeBoundsTree: typeof disposeBoundsTree;
+    }
+  ).disposeBoundsTree = disposeBoundsTree;
+  patchesInstalled = true;
+}
+
+/**
+ * Build a bounds tree (BVH) on `mesh.geometry` so subsequent
+ * `raycaster.intersectObject(mesh)` calls are O(log N) instead of O(N).
+ *
+ * Calls `installAcceleratedRaycast()` transitively, so a caller that only
+ * imports this function gets both the patches and the per-mesh tree.
+ *
+ * Re-entrant: if a tree already exists on the geometry, it's disposed
+ * first and a fresh one is built. This matches the lifecycle in
+ * `master.ts`: every new STL gets a new bounds tree, the previous tree
+ * is released.
+ */
+export function prepareMeshForPicking(mesh: Mesh): void {
+  installAcceleratedRaycast();
+  const geom = mesh.geometry as BufferGeometry & {
+    boundsTree?: unknown;
+    computeBoundsTree?: () => void;
+    disposeBoundsTree?: () => void;
+  };
+  if (geom.boundsTree && geom.disposeBoundsTree) {
+    geom.disposeBoundsTree();
+  }
+  if (geom.computeBoundsTree) {
+    geom.computeBoundsTree();
+  }
+}
+
+/**
+ * Release the BVH attached to `mesh.geometry`, if any. Idempotent:
+ * safe to call on meshes that never had a tree installed.
+ *
+ * Call this from the disposal path when a master mesh is swapped out —
+ * see `disposeMesh` in `master.ts`.
+ */
+export function releaseMeshPicking(mesh: Mesh): void {
+  const geom = mesh.geometry as BufferGeometry & {
+    boundsTree?: unknown;
+    disposeBoundsTree?: () => void;
+  };
+  if (geom.boundsTree && geom.disposeBoundsTree) {
+    geom.disposeBoundsTree();
+  }
+}
+
+/** Result of a successful face pick. */
+export interface PickResult {
+  /** Index of the picked triangle in the mesh's BufferGeometry. */
+  readonly faceIndex: number;
+  /** World-space hit point. */
+  readonly point: Vector3;
+  /** World-space face normal (unit length). */
+  readonly worldNormal: Vector3;
+  /** Mesh-local face normal (unit length). */
+  readonly localNormal: Vector3;
+}
+
+/**
+ * Pointer-like shape we accept as input. We don't need the full
+ * `PointerEvent` interface — just the client coordinates. Using a
+ * structural type means test harnesses can pass plain objects.
+ */
+export interface PointerLike {
+  readonly clientX: number;
+  readonly clientY: number;
+}
+
+/**
+ * Raycast the pointer against `mesh`, returning the closest hit or `null`.
+ *
+ * Coordinate math:
+ *   - Convert `(clientX, clientY)` relative to `canvas.getBoundingClientRect()`
+ *     into normalised device coordinates in [-1, 1].
+ *   - `Raycaster.setFromCamera(ndc, camera)` then emits a world-space ray.
+ *   - `intersectObject(mesh, recursive=false)` returns hits sorted by
+ *     distance; we take the first.
+ *
+ * Normal math:
+ *   - Three.js populates `intersection.face.normal` with the face's
+ *     mesh-LOCAL normal. For the lay-flat math we need the WORLD normal,
+ *     which is a transform via the mesh's normal matrix. `layFlat.ts`
+ *     owns that conversion (`localNormalToWorld`).
+ */
+export function pickFaceUnderPointer(
+  event: PointerLike,
+  canvas: HTMLCanvasElement,
+  camera: PerspectiveCamera,
+  mesh: Mesh,
+): PickResult | null {
+  const rect = canvas.getBoundingClientRect();
+  // Guard against unmounted canvas (0x0) — no valid NDC possible.
+  if (rect.width <= 0 || rect.height <= 0) return null;
+
+  const ndc = new Vector2(
+    ((event.clientX - rect.left) / rect.width) * 2 - 1,
+    // NDC Y is inverted: canvas top is +1, bottom is -1.
+    -(((event.clientY - rect.top) / rect.height) * 2 - 1),
+  );
+
+  const raycaster = new Raycaster();
+  raycaster.setFromCamera(ndc, camera);
+
+  const hits = raycaster.intersectObject(mesh, /* recursive */ false);
+  if (hits.length === 0) return null;
+
+  const hit = hits[0]!;
+  if (!hit.face) return null;
+  const faceIndex = typeof hit.faceIndex === 'number' ? hit.faceIndex : -1;
+  if (faceIndex < 0) return null;
+
+  const localNormal = hit.face.normal.clone().normalize();
+  const worldNormal = localNormalToWorld(mesh, localNormal);
+
+  return {
+    faceIndex,
+    point: hit.point.clone(),
+    worldNormal,
+    localNormal,
+  };
+}

--- a/src/renderer/scene/viewport.ts
+++ b/src/renderer/scene/viewport.ts
@@ -16,7 +16,7 @@
 //      spec. Does NOT enable test-hook exposure.
 
 import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import type { PerspectiveCamera, Scene, WebGLRenderer } from 'three';
+import type { Mesh, PerspectiveCamera, Scene, WebGLRenderer } from 'three';
 
 import { createCamera, computeAspect, frameToBox3 } from './camera';
 import { createControls } from './controls';
@@ -26,6 +26,7 @@ import {
   OVERLAY_SIZE_PX,
   type AxesGizmoOverlay,
 } from './gizmos';
+import { createLayFlatController, type LayFlatController } from './layFlatController';
 import { createRenderer, resizeRendererToContainer } from './renderer';
 import { createScene } from './index';
 import { setMaster as sceneSetMaster, type MasterResult } from './master';
@@ -54,6 +55,22 @@ export interface MountedViewport {
    * readout).
    */
   setMaster: (buffer: ArrayBuffer) => Promise<MasterResult>;
+  /**
+   * Enter "Place on face" (lay-flat) mode. Pointer move highlights the
+   * face under the cursor; click commits a rotation so that face lies
+   * flat on the print bed. No-op if no master is loaded. Escape key exits.
+   */
+  enableFacePicking: () => void;
+  /** Exit "Place on face" mode. Safe to call when already inactive. */
+  disableFacePicking: () => void;
+  /** Whether face-picking mode is currently active. */
+  isFacePickingActive: () => boolean;
+  /**
+   * Reset the master's orientation to identity and re-run the auto-center
+   * pass. The camera is re-framed to the restored AABB. No-op when no
+   * master is loaded.
+   */
+  resetOrientation: () => void;
   /** Stop RAF, detach listeners, dispose GPU resources, remove the canvas. */
   dispose: () => void;
 }
@@ -78,6 +95,19 @@ export function mount(container: HTMLElement): MountedViewport {
 
   // Initial size sync after everything is wired.
   syncSize(renderer, camera, container);
+
+  // Lay-flat (Place-on-face) controller. Widgets attach to the scene's
+  // 'widgets' group (created by createScene). The controller is idle
+  // until `enableFacePicking()` is called. It holds a getter reference
+  // to the current master so swap-master (below) keeps it working.
+  let layFlatMasterMesh: Mesh | null = null;
+  const layFlat: LayFlatController = createLayFlatController({
+    scene,
+    camera,
+    controls,
+    canvas,
+    getMasterMesh: () => layFlatMasterMesh,
+  });
 
   // Resize: a ResizeObserver on the container catches every layout change
   // (window resize, devtools dock, split-pane drag). Falls back to
@@ -152,7 +182,12 @@ export function mount(container: HTMLElement): MountedViewport {
   });
 
   const setMaster = async (buffer: ArrayBuffer): Promise<MasterResult> => {
+    // Exit any active lay-flat session before swapping the master — the old
+    // mesh (and its BVH) is about to be disposed, and stale cursor listeners
+    // would point at freed GPU resources.
+    if (layFlat.isActive()) layFlat.disable();
     const result = await sceneSetMaster(scene, buffer);
+    layFlatMasterMesh = result.mesh;
     frameToBox3(camera, controls, result.bbox);
     // Signal test hooks, then install a fresh promise so a second load
     // is independently awaitable.
@@ -204,6 +239,7 @@ export function mount(container: HTMLElement): MountedViewport {
     } else {
       window.removeEventListener('resize', onWindowResize);
     }
+    layFlat.dispose();
     controls.dispose();
     renderer.dispose();
     if (canvas.parentElement === container) {
@@ -218,6 +254,10 @@ export function mount(container: HTMLElement): MountedViewport {
     controls,
     axes,
     setMaster,
+    enableFacePicking: () => layFlat.enable(),
+    disableFacePicking: () => layFlat.disable(),
+    isFacePickingActive: () => layFlat.isActive(),
+    resetOrientation: () => layFlat.reset(),
     dispose,
   };
 

--- a/src/renderer/ui/placeOnFaceToggle.ts
+++ b/src/renderer/ui/placeOnFaceToggle.ts
@@ -1,0 +1,130 @@
+// src/renderer/ui/placeOnFaceToggle.ts
+//
+// Two buttons:
+//
+//   [ Place on face ]    toggles lay-flat picking mode
+//   [ Reset orientation ] reverts to identity + recenters
+//
+// Issue #32 lets us place these in the sidebar OR the toolbar — the app
+// has no sidebar yet, so we mount alongside the Open STL button in the
+// topbar center slot. Coordinate with the parameter-form PR #31 if that
+// lands first; the two toolbars compose cleanly because both live under
+// `header.topbar__center`.
+//
+// The toggle is pressed-state-driven: `aria-pressed` + an `.is-active`
+// class mirror the internal boolean. i18n keys are namespaced under
+// `layFlat.*` so they are easy to locate in en.json.
+
+import { t } from '../i18n';
+
+/** Imperative API for the mounted toggle. */
+export interface PlaceOnFaceToggleApi {
+  /** Programmatically flip picking state. Mirrors a user click. */
+  setActive(active: boolean): void;
+  /** Enable or disable the two buttons (e.g. when no master is loaded). */
+  setEnabled(enabled: boolean): void;
+  /** Read the visible active state. */
+  isActive(): boolean;
+  /** Remove from DOM + detach listeners. Unused today, tidy. */
+  destroy(): void;
+}
+
+/** Callbacks supplied by the caller (wired in main.ts to the viewport). */
+export interface PlaceOnFaceToggleHandlers {
+  /** User flipped the main toggle. Implementation calls viewport.enable/disable. */
+  onToggle(active: boolean): void;
+  /** User clicked Reset orientation. Implementation calls viewport.resetOrientation. */
+  onReset(): void;
+}
+
+/**
+ * Mount the toggle + reset buttons into `host`. Both buttons render disabled
+ * until the caller calls `setEnabled(true)` — typically after the first
+ * master mesh is loaded.
+ */
+export function mountPlaceOnFaceToggle(
+  host: HTMLElement,
+  handlers: PlaceOnFaceToggleHandlers,
+): PlaceOnFaceToggleApi {
+  const root = document.createElement('div');
+  root.className = 'place-on-face';
+  root.dataset['testid'] = 'place-on-face';
+
+  // --- Primary toggle ---
+  const toggleBtn = document.createElement('button');
+  toggleBtn.type = 'button';
+  toggleBtn.className = 'place-on-face__toggle';
+  toggleBtn.dataset['testid'] = 'place-on-face-toggle';
+  toggleBtn.textContent = t('layFlat.toggle');
+  toggleBtn.title = t('layFlat.toggleHint');
+  toggleBtn.setAttribute('aria-pressed', 'false');
+  toggleBtn.disabled = true;
+
+  // --- Reset button ---
+  const resetBtn = document.createElement('button');
+  resetBtn.type = 'button';
+  resetBtn.className = 'place-on-face__reset';
+  resetBtn.dataset['testid'] = 'place-on-face-reset';
+  resetBtn.textContent = t('layFlat.reset');
+  resetBtn.title = t('layFlat.resetHint');
+  resetBtn.disabled = true;
+
+  root.appendChild(toggleBtn);
+  root.appendChild(resetBtn);
+  host.appendChild(root);
+
+  let active = false;
+  let enabled = false;
+
+  function renderActive(): void {
+    toggleBtn.setAttribute('aria-pressed', active ? 'true' : 'false');
+    toggleBtn.classList.toggle('is-active', active);
+  }
+
+  function renderEnabled(): void {
+    toggleBtn.disabled = !enabled;
+    resetBtn.disabled = !enabled;
+  }
+
+  function choose(newActive: boolean): void {
+    if (active === newActive) return;
+    active = newActive;
+    renderActive();
+    handlers.onToggle(active);
+  }
+
+  toggleBtn.addEventListener('click', () => {
+    if (!enabled) return;
+    choose(!active);
+  });
+  resetBtn.addEventListener('click', () => {
+    if (!enabled) return;
+    handlers.onReset();
+  });
+
+  renderActive();
+  renderEnabled();
+
+  return {
+    setActive(next: boolean): void {
+      if (active === next) return;
+      active = next;
+      renderActive();
+      // `setActive` is a programmatic reflection of viewport state — do NOT
+      // call `handlers.onToggle` here or we'd loop (viewport → toggle →
+      // viewport). The caller only uses this to surface the auto-exit-
+      // on-commit transition back into the UI.
+    },
+    setEnabled(next: boolean): void {
+      if (enabled === next) return;
+      enabled = next;
+      renderEnabled();
+    },
+    isActive(): boolean {
+      return active;
+    },
+    destroy(): void {
+      root.remove();
+    },
+  };
+}

--- a/tests/e2e/lay-flat.spec.ts
+++ b/tests/e2e/lay-flat.spec.ts
@@ -272,3 +272,119 @@ test('lay-flat: pick top face → mesh re-seats on Y=0 + vertex buffer unchanged
     await app.close();
   }
 });
+
+// ---------------------------------------------------------------------------
+// Non-blocking follow-ups from PR #34 QA (round 1):
+//   - Escape exits picking mode (AC #1 of issue #32).
+//   - `enableFacePicking()` sets `canvas.style.cursor = 'crosshair'`
+//     (AC #1 of issue #32).
+// Both run in a single Electron launch to amortise the ~3 s boot cost.
+// ---------------------------------------------------------------------------
+
+test('lay-flat UX: Escape exits picking mode + cursor becomes crosshair on enable', async () => {
+  const app = await launchApp();
+  try {
+    const page = await app.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
+
+    await app.evaluate((_electron, fixturePath) => {
+      (
+        globalThis as unknown as {
+          __testDialogStub: {
+            showOpenDialog: () => Promise<{
+              canceled: boolean;
+              filePaths: string[];
+            }>;
+          };
+        }
+      ).__testDialogStub = {
+        showOpenDialog: () =>
+          Promise.resolve({ canceled: false, filePaths: [fixturePath] }),
+      };
+    }, MINI_FIGURINE_PATH);
+
+    const openBtn = page.locator('[data-testid="open-stl-btn"]');
+    await expect(openBtn).toBeVisible();
+
+    // Snapshot the masterLoaded promise BEFORE clicking Open STL.
+    await page.evaluate(() => {
+      const hooks = (
+        window as unknown as {
+          __testHooks?: { masterLoaded?: Promise<void> };
+        }
+      ).__testHooks;
+      if (!hooks?.masterLoaded) {
+        throw new Error('window.__testHooks.masterLoaded missing');
+      }
+      (
+        globalThis as unknown as { __pendingMasterLoaded: Promise<void> }
+      ).__pendingMasterLoaded = hooks.masterLoaded;
+    });
+
+    await openBtn.click();
+    await page.evaluate(
+      () =>
+        (
+          globalThis as unknown as { __pendingMasterLoaded: Promise<void> }
+        ).__pendingMasterLoaded,
+    );
+
+    // Enable face-picking and verify the cursor becomes crosshair AND the
+    // controller reports active.
+    await page.evaluate(() => {
+      type ViewportHooks = {
+        viewport?: {
+          enableFacePicking: () => void;
+          isFacePickingActive: () => boolean;
+        };
+      };
+      const hooks = (window as unknown as { __testHooks?: ViewportHooks })
+        .__testHooks;
+      const vp = hooks?.viewport;
+      if (!vp) throw new Error('viewport hook missing');
+      vp.enableFacePicking();
+      if (!vp.isFacePickingActive()) {
+        throw new Error('face-picking did not activate');
+      }
+    });
+
+    // AC #1 — cursor becomes crosshair on the canvas.
+    const cursorAfterEnable = await page.evaluate(() => {
+      const canvas = document.querySelector(
+        '#viewport canvas',
+      ) as HTMLCanvasElement | null;
+      return canvas?.style.cursor ?? '';
+    });
+    expect(cursorAfterEnable).toBe('crosshair');
+
+    // AC #1 — Escape exits picking mode. We dispatch a keydown on the
+    // window (the controller attaches the listener there, not on the
+    // canvas — matches browser conventions for global shortcuts).
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+      );
+    });
+
+    const stateAfterEscape = await page.evaluate(() => {
+      type ViewportHooks = {
+        viewport?: { isFacePickingActive: () => boolean };
+      };
+      const hooks = (window as unknown as { __testHooks?: ViewportHooks })
+        .__testHooks;
+      return hooks?.viewport?.isFacePickingActive() ?? null;
+    });
+    expect(stateAfterEscape).toBe(false);
+
+    // Cursor reverts on disable (empty string = inherits from CSS).
+    const cursorAfterEscape = await page.evaluate(() => {
+      const canvas = document.querySelector(
+        '#viewport canvas',
+      ) as HTMLCanvasElement | null;
+      return canvas?.style.cursor ?? 'missing';
+    });
+    expect(cursorAfterEscape).toBe('');
+  } finally {
+    await app.close();
+  }
+});

--- a/tests/e2e/lay-flat.spec.ts
+++ b/tests/e2e/lay-flat.spec.ts
@@ -243,10 +243,19 @@ test('lay-flat: pick top face → mesh re-seats on Y=0 + vertex buffer unchanged
       return arr;
     });
     expect(afterBuffer.length).toBe(beforeBuffer.length);
+    // Compare BYTE-IDENTICALLY using a single `expect` — a per-index loop
+    // of `.toBe` over 51k entries adds ~2 ms of matcher overhead per call
+    // in Playwright's context, blowing past the 30 s test budget. Locating
+    // the first mismatching index (if any) keeps the failure message
+    // actionable without flooding the matcher with 50k calls.
+    let firstMismatch = -1;
     for (let i = 0; i < beforeBuffer.length; i++) {
-      // Exact equality — NO FP tolerance. The buffer must not be touched.
-      expect(afterBuffer[i]).toBe(beforeBuffer[i]);
+      if (afterBuffer[i] !== beforeBuffer[i]) {
+        firstMismatch = i;
+        break;
+      }
     }
+    expect(firstMismatch, 'vertex buffer was mutated at index').toBe(-1);
 
     // The group quaternion moved off identity (a rotation actually happened).
     const isRotated = await page.evaluate(() => {

--- a/tests/e2e/lay-flat.spec.ts
+++ b/tests/e2e/lay-flat.spec.ts
@@ -1,0 +1,274 @@
+// tests/e2e/lay-flat.spec.ts
+//
+// End-to-end for issue #32 ("Place on face"). Launches the real Electron
+// app, loads the mini-figurine fixture via the stubbed native Open dialog,
+// enters picking mode, synthesises a click at a screen position where
+// the rendered mesh is known to have a visible top surface, and asserts:
+//
+//   - After the click, the Master group's world-space AABB has min.y ≈ 0
+//     with 1e-4 mm tolerance.
+//   - The mesh.geometry.attributes.position buffer is BYTE-IDENTICAL
+//     before and after the click — proves the lay-flat invariant
+//     ("viewport transforms live on the Group, never on the geometry").
+//   - The group's quaternion has moved off identity (the rotation
+//     actually happened).
+//
+// We drive the interaction through `window.__testHooks.viewport` rather
+// than synthesising pointer events on the canvas, because synthetic
+// pointermove events don't reliably route to Three.js `Raycaster` inside
+// Electron's Chromium without a layered PointerEvent polyfill. The
+// controller ultimately calls `pickFaceUnderPointer(event, canvas, ...)`
+// so we invoke the viewport-level API and supply a synthetic click
+// position via the exposed picking helpers.
+
+import { expect, test } from '@playwright/test';
+import { resolve } from 'node:path';
+import { launchApp } from './fixtures/app';
+
+const MINI_FIGURINE_PATH = resolve(
+  __dirname,
+  '..',
+  'fixtures',
+  'meshes',
+  'mini-figurine.stl',
+);
+
+test('lay-flat: pick top face → mesh re-seats on Y=0 + vertex buffer unchanged', async () => {
+  const app = await launchApp();
+  try {
+    const page = await app.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
+
+    page.on('console', (msg) => {
+      console.log(`[renderer:${msg.type()}] ${msg.text()}`);
+    });
+    page.on('pageerror', (err) => {
+      console.log(`[renderer:pageerror] ${err.message}`);
+    });
+
+    await app.evaluate((_electron, fixturePath) => {
+      (
+        globalThis as unknown as {
+          __testDialogStub: {
+            showOpenDialog: () => Promise<{
+              canceled: boolean;
+              filePaths: string[];
+            }>;
+          };
+        }
+      ).__testDialogStub = {
+        showOpenDialog: () =>
+          Promise.resolve({ canceled: false, filePaths: [fixturePath] }),
+      };
+    }, MINI_FIGURINE_PATH);
+
+    const openBtn = page.locator('[data-testid="open-stl-btn"]');
+    await expect(openBtn).toBeVisible();
+    await expect(openBtn).toBeEnabled();
+
+    // Snapshot the masterLoaded promise BEFORE clicking Open STL.
+    await page.evaluate(() => {
+      const hooks = (
+        window as unknown as {
+          __testHooks?: { masterLoaded?: Promise<void> };
+        }
+      ).__testHooks;
+      if (!hooks?.masterLoaded) {
+        throw new Error('window.__testHooks.masterLoaded missing');
+      }
+      (
+        globalThis as unknown as { __pendingMasterLoaded: Promise<void> }
+      ).__pendingMasterLoaded = hooks.masterLoaded;
+    });
+
+    await openBtn.click();
+    await page.evaluate(
+      () =>
+        (
+          globalThis as unknown as { __pendingMasterLoaded: Promise<void> }
+        ).__pendingMasterLoaded,
+    );
+
+    // Capture a baseline of the mesh's vertex buffer before lay-flat.
+    // `position.array` is a Float32Array; we serialise to a regular array
+    // so Playwright can transport it across the worker boundary.
+    const beforeBuffer: number[] = await page.evaluate(() => {
+      type Hooks = {
+        scene?: { traverse: (cb: (o: { userData?: Record<string, unknown>; type?: string; geometry?: { getAttribute: (n: string) => { array: ArrayLike<number> } } }) => void) => void };
+      };
+      const hooks = (window as unknown as { __testHooks?: Hooks }).__testHooks;
+      const scene = hooks?.scene;
+      if (!scene) throw new Error('scene hook missing');
+      let meshArr: number[] | null = null;
+      scene.traverse((obj) => {
+        if (
+          obj.userData?.['tag'] === 'master' &&
+          obj.type === 'Mesh' &&
+          obj.geometry
+        ) {
+          const attr = obj.geometry.getAttribute('position');
+          meshArr = Array.from(attr.array);
+        }
+      });
+      if (!meshArr) throw new Error('master mesh missing');
+      return meshArr;
+    });
+    expect(beforeBuffer.length).toBeGreaterThan(0);
+
+    // Enter picking mode + commit the TOP face (we know the mini-figurine
+    // fixture sits centered on the bed after auto-center, so a ray from
+    // straight above hits the highest face). We drive the controller by
+    // temporarily repositioning the camera and hand-synthesising a click
+    // at the canvas center.
+    await page.evaluate(() => {
+      type ViewportHooks = {
+        viewport?: {
+          scene: unknown;
+          camera: {
+            position: { set: (x: number, y: number, z: number) => void };
+            up: { set: (x: number, y: number, z: number) => void };
+            lookAt: (x: number, y: number, z: number) => void;
+            updateMatrixWorld: () => void;
+            updateProjectionMatrix: () => void;
+          };
+          enableFacePicking: () => void;
+        };
+      };
+      const hooks = (window as unknown as { __testHooks?: ViewportHooks })
+        .__testHooks;
+      const vp = hooks?.viewport;
+      if (!vp) throw new Error('viewport hook missing');
+      // Aim the camera straight down the -Y axis so a ray from the canvas
+      // centre hits the top of the mini-figurine. The fixture's post-
+      // auto-center AABB is ~[−42, 0, −20] → [+42, +70, +90] mm
+      // (its 2026-04-19 volume = 127 k mm³), so placing the camera at
+      // (0, 250, 0) looking at (0, 35, 0) puts the top face in the
+      // middle of the frame.
+      vp.camera.position.set(0, 250, 0);
+      vp.camera.up.set(0, 0, -1);
+      vp.camera.lookAt(0, 35, 0);
+      vp.camera.updateMatrixWorld();
+      vp.camera.updateProjectionMatrix();
+      vp.enableFacePicking();
+    });
+
+    // Synthesise a pointerdown → click at the canvas centre.
+    const canvasBox = await page.locator('#viewport canvas').boundingBox();
+    if (!canvasBox) throw new Error('canvas missing');
+    const cx = canvasBox.x + canvasBox.width / 2;
+    const cy = canvasBox.y + canvasBox.height / 2;
+    await page.mouse.move(cx, cy);
+    await page.mouse.click(cx, cy);
+
+    // Give the RAF loop a tick to apply the rotation + re-center.
+    // Then assert the post-commit world bbox satisfies min.y ≈ 0.
+    await page.waitForFunction(
+      () => {
+        type ViewportHooks = {
+          viewport?: { isFacePickingActive: () => boolean };
+        };
+        const hooks = (window as unknown as { __testHooks?: ViewportHooks })
+          .__testHooks;
+        // Controller auto-exits on commit — use that as the "done" signal.
+        return hooks?.viewport?.isFacePickingActive() === false;
+      },
+      undefined,
+      { timeout: 5_000 },
+    );
+
+    const worldMinY: number = await page.evaluate(() => {
+      // Find the master mesh via scene traversal.
+      type MeshShape = {
+        userData?: Record<string, unknown>;
+        type?: string;
+        matrixWorld: { elements: Float32Array | number[] };
+        geometry: { getAttribute: (n: string) => { array: Float32Array; count: number } };
+        updateMatrixWorld: (force: boolean) => void;
+      };
+      type Hooks = {
+        scene?: { traverse: (cb: (o: unknown) => void) => void };
+      };
+      const hooks = (window as unknown as { __testHooks?: Hooks }).__testHooks;
+      const scene = hooks?.scene;
+      if (!scene) throw new Error('scene hook missing');
+      let found: MeshShape | null = null;
+      scene.traverse((obj: unknown) => {
+        const o = obj as MeshShape;
+        if (o.userData?.['tag'] === 'master' && o.type === 'Mesh') {
+          found = o;
+        }
+      });
+      if (!found) throw new Error('master mesh missing');
+      const m: MeshShape = found;
+      // Compute world-space min.y by applying mesh.matrixWorld (4x4) to
+      // each local vertex and tracking the minimum Y. Equivalent to
+      // `Box3().setFromObject(mesh).min.y` but doesn't require a Box3
+      // import inside the page context.
+      m.updateMatrixWorld(true);
+      const e = m.matrixWorld.elements;
+      const attr = m.geometry.getAttribute('position');
+      const arr = attr.array;
+      let minY = Infinity;
+      for (let i = 0; i < attr.count; i++) {
+        const x = arr[i * 3]!;
+        const y = arr[i * 3 + 1]!;
+        const z = arr[i * 3 + 2]!;
+        const worldY = e[1]! * x + e[5]! * y + e[9]! * z + e[13]!;
+        if (worldY < minY) minY = worldY;
+      }
+      return minY;
+    });
+    expect(worldMinY).toBeCloseTo(0, 4); // 1e-4 mm tolerance.
+
+    // Vertex buffer is UNCHANGED.
+    const afterBuffer: number[] = await page.evaluate(() => {
+      type Hooks = {
+        scene?: { traverse: (cb: (o: { userData?: Record<string, unknown>; type?: string; geometry?: { getAttribute: (n: string) => { array: ArrayLike<number> } } }) => void) => void };
+      };
+      const hooks = (window as unknown as { __testHooks?: Hooks }).__testHooks;
+      const scene = hooks?.scene;
+      if (!scene) throw new Error('scene hook missing');
+      let arr: number[] | null = null;
+      scene.traverse((obj) => {
+        if (
+          obj.userData?.['tag'] === 'master' &&
+          obj.type === 'Mesh' &&
+          obj.geometry
+        ) {
+          const a = obj.geometry.getAttribute('position');
+          arr = Array.from(a.array);
+        }
+      });
+      if (!arr) throw new Error('master mesh missing');
+      return arr;
+    });
+    expect(afterBuffer.length).toBe(beforeBuffer.length);
+    for (let i = 0; i < beforeBuffer.length; i++) {
+      // Exact equality — NO FP tolerance. The buffer must not be touched.
+      expect(afterBuffer[i]).toBe(beforeBuffer[i]);
+    }
+
+    // The group quaternion moved off identity (a rotation actually happened).
+    const isRotated = await page.evaluate(() => {
+      type MeshShape = { userData?: Record<string, unknown>; type?: string };
+      type Hooks = { scene?: { traverse: (cb: (o: MeshShape) => void) => void; children: unknown[] } };
+      const hooks = (window as unknown as { __testHooks?: Hooks }).__testHooks;
+      const scene = hooks?.scene;
+      if (!scene) throw new Error('scene hook missing');
+      // The Master group is the scene child with tag 'master'.
+      const group = (
+        scene.children as unknown as Array<{
+          userData?: Record<string, unknown>;
+          quaternion?: { x: number; y: number; z: number; w: number };
+        }>
+      ).find((c) => c.userData?.['tag'] === 'master');
+      if (!group?.quaternion) return false;
+      const { x, y, z, w } = group.quaternion;
+      const deltaFromIdentity = Math.hypot(x, y, z, w - 1);
+      return deltaFromIdentity > 1e-4;
+    });
+    expect(isRotated).toBe(true);
+  } finally {
+    await app.close();
+  }
+});

--- a/tests/renderer/scene/layFlat.test.ts
+++ b/tests/renderer/scene/layFlat.test.ts
@@ -1,0 +1,295 @@
+// tests/renderer/scene/layFlat.test.ts
+//
+// Unit tests for the lay-flat pure-math helpers in
+// `src/renderer/scene/layFlat.ts`. These tests cover every acceptance
+// criterion from issue #32 that is expressible in node-only geometry:
+//
+//   1. `quaternionToAlignFaceDown((0,1,0))` sends +Y to −Y (flip).
+//   2. `quaternionToAlignFaceDown((1,0,0))` sends +X to −Y.
+//   3. `quaternionToAlignFaceDown((0,-1,0))` is (≈) identity.
+//   4. `recenterGroup` on a rotated group produces a world-space bbox
+//      with `min.y === 0` and `center.xz ≈ 0` — i.e. it honours the
+//      same "on-the-bed + xz-centered" contract `setMaster` does, but
+//      under a non-trivial group rotation.
+//   5. `resetOrientation` restores identity + re-applies auto-center.
+//   6. BufferGeometry position buffer is UNCHANGED after lay-flat
+//      rotation (the critical invariant from PR #29).
+//   7. `localNormalToWorld` applies the group's rotation correctly.
+//
+// The tests use a tiny synthetic Mesh (a 2×1×1 box) rather than the real
+// STL loader — we only care about the geometry math here, not the STL
+// round-trip. A separate `master.test.ts` covers the setMaster path.
+
+import {
+  BoxGeometry,
+  Box3,
+  Group,
+  Mesh,
+  MeshBasicMaterial,
+  Quaternion,
+  Vector3,
+} from 'three';
+import { describe, expect, test } from 'vitest';
+
+import {
+  localNormalToWorld,
+  quaternionToAlignFaceDown,
+  recenterGroup,
+  resetOrientation,
+} from '@/renderer/scene/layFlat';
+
+/**
+ * Build a Group with a box mesh as its child, placed at a known offset
+ * inside the group so the child has a non-trivial world-space bbox under
+ * both identity and rotated group orientations. Mimics the scene-graph
+ * structure `setMaster` builds (Master group → mesh).
+ */
+function buildGroupWithBox(): { group: Group; mesh: Mesh } {
+  const group = new Group();
+  // 2 mm wide, 1 mm tall, 1 mm deep. Default-centered on origin.
+  const geom = new BoxGeometry(2, 1, 1);
+  const mat = new MeshBasicMaterial();
+  const mesh = new Mesh(geom, mat);
+  group.add(mesh);
+  return { group, mesh };
+}
+
+/** Apply `q` to `v` and return a fresh Vector3 — avoids mutating input. */
+function rotate(v: Vector3, q: Quaternion): Vector3 {
+  return v.clone().applyQuaternion(q);
+}
+
+describe('quaternionToAlignFaceDown', () => {
+  test('sends +Y normal to -Y (face-up → face-down flip)', () => {
+    const q = quaternionToAlignFaceDown(new Vector3(0, 1, 0));
+    const rotated = rotate(new Vector3(0, 1, 0), q);
+    // The rotated normal must be (0, -1, 0) within tolerance. Three picks
+    // either an X-flip or Z-flip as the rotation axis; either is valid —
+    // both produce the same result on the input normal.
+    expect({ x: rotated.x, y: rotated.y, z: rotated.z }).toEqualWithTolerance(
+      { x: 0, y: -1, z: 0 },
+      { abs: 1e-6 },
+    );
+  });
+
+  test('sends +X normal to -Y', () => {
+    const q = quaternionToAlignFaceDown(new Vector3(1, 0, 0));
+    const rotated = rotate(new Vector3(1, 0, 0), q);
+    expect({ x: rotated.x, y: rotated.y, z: rotated.z }).toEqualWithTolerance(
+      { x: 0, y: -1, z: 0 },
+      { abs: 1e-6 },
+    );
+  });
+
+  test('sends -Y (already down) to itself — quaternion is ≈ identity', () => {
+    const q = quaternionToAlignFaceDown(new Vector3(0, -1, 0));
+    // Identity quaternion has w=1, x=y=z=0. Three's setFromUnitVectors
+    // short-circuits to identity when the dot product ≈ 1.
+    expect({ x: q.x, y: q.y, z: q.z, w: q.w }).toEqualWithTolerance(
+      { x: 0, y: 0, z: 0, w: 1 },
+      { abs: 1e-6 },
+    );
+  });
+
+  test('normalises a non-unit input before computing', () => {
+    // A non-unit +Y should still produce the same flip — the helper
+    // must normalise internally.
+    const q = quaternionToAlignFaceDown(new Vector3(0, 17.4, 0));
+    const rotated = rotate(new Vector3(0, 1, 0), q);
+    expect(rotated.y).toEqualWithTolerance(-1, { abs: 1e-6 });
+  });
+
+  test('sends an oblique (1,1,1)/√3 normal to -Y', () => {
+    const n = new Vector3(1, 1, 1).normalize();
+    const q = quaternionToAlignFaceDown(n);
+    const rotated = rotate(n, q);
+    expect({ x: rotated.x, y: rotated.y, z: rotated.z }).toEqualWithTolerance(
+      { x: 0, y: -1, z: 0 },
+      { abs: 1e-6 },
+    );
+  });
+});
+
+describe('recenterGroup', () => {
+  test('on identity rotation, offsets so min.y = 0 and xz-center = 0', () => {
+    const { group, mesh } = buildGroupWithBox();
+    // Box is 2×1×1 centered at origin → AABB (-1,-0.5,-0.5)–(1,0.5,0.5).
+    // Expected offset: (0, 0.5, 0) → min.y becomes 0.
+    const offset = recenterGroup(group, mesh);
+    expect({ x: offset.x, y: offset.y, z: offset.z }).toEqualWithTolerance(
+      { x: 0, y: 0.5, z: 0 },
+      { abs: 1e-6 },
+    );
+    const worldBbox = new Box3().setFromObject(mesh);
+    expect(worldBbox.min.y).toEqualWithTolerance(0, { abs: 1e-6 });
+    const worldCenter = new Vector3();
+    worldBbox.getCenter(worldCenter);
+    expect(worldCenter.x).toEqualWithTolerance(0, { abs: 1e-6 });
+    expect(worldCenter.z).toEqualWithTolerance(0, { abs: 1e-6 });
+  });
+
+  test('on a non-identity rotation, re-centers the rotated bbox', () => {
+    const { group, mesh } = buildGroupWithBox();
+    // Rotate 90° around +X so the box's original +Y face ends up at +Z.
+    // The 2×1×1 box becomes a 2×1×1 block with extents:
+    //   x: [-1, 1], y: [-0.5, 0.5] (was -0.5..0.5 on z), z: [-0.5, 0.5].
+    group.quaternion.setFromAxisAngle(new Vector3(1, 0, 0), Math.PI / 2);
+
+    const offset = recenterGroup(group, mesh);
+    // Under this rotation, min.y is the lower bound on the new Y extent,
+    // which is -0.5. So offset.y must be +0.5 to bring min.y to 0.
+    expect(offset.y).toEqualWithTolerance(0.5, { abs: 1e-6 });
+
+    // World-space bbox after recenter must satisfy the on-the-bed
+    // contract, regardless of rotation.
+    const worldBbox = new Box3().setFromObject(mesh);
+    expect(worldBbox.min.y).toEqualWithTolerance(0, { abs: 1e-6 });
+    const worldCenter = new Vector3();
+    worldBbox.getCenter(worldCenter);
+    expect(worldCenter.x).toEqualWithTolerance(0, { abs: 1e-6 });
+    expect(worldCenter.z).toEqualWithTolerance(0, { abs: 1e-6 });
+  });
+
+  test('handles a composed rotation (two lay-flats chained)', () => {
+    const { group, mesh } = buildGroupWithBox();
+    // Compose two quaternions: first flip +Y → -Y, then (on top) rotate
+    // 45° around +Z. `premultiply` is the composition order the
+    // controller uses — verify recenter works under it.
+    const qFlip = quaternionToAlignFaceDown(new Vector3(0, 1, 0));
+    const q45 = new Quaternion().setFromAxisAngle(
+      new Vector3(0, 0, 1),
+      Math.PI / 4,
+    );
+    group.quaternion.copy(qFlip);
+    group.quaternion.premultiply(q45);
+
+    recenterGroup(group, mesh);
+    const worldBbox = new Box3().setFromObject(mesh);
+    expect(worldBbox.min.y).toEqualWithTolerance(0, { abs: 1e-6 });
+  });
+});
+
+describe('resetOrientation', () => {
+  test('restores identity quaternion and re-applies auto-center', () => {
+    const { group, mesh } = buildGroupWithBox();
+    // Start from a rotated + re-centered state.
+    group.quaternion.setFromAxisAngle(new Vector3(1, 0, 0), Math.PI / 3);
+    recenterGroup(group, mesh);
+    // Sanity: under non-identity rotation the offset is non-zero in Y.
+    expect(group.position.y).not.toEqualWithTolerance(0.5, { abs: 1e-6 });
+
+    resetOrientation(group, mesh);
+    // Identity rotation restores the 2×1×1 box's natural AABB, so the
+    // offset collapses to (0, 0.5, 0) — same as the very first
+    // `recenterGroup` call in the identity-rotation test.
+    expect({ x: group.position.x, y: group.position.y, z: group.position.z })
+      .toEqualWithTolerance({ x: 0, y: 0.5, z: 0 }, { abs: 1e-6 });
+    // Quaternion is exactly identity.
+    expect({
+      x: group.quaternion.x,
+      y: group.quaternion.y,
+      z: group.quaternion.z,
+      w: group.quaternion.w,
+    }).toEqualWithTolerance({ x: 0, y: 0, z: 0, w: 1 }, { abs: 1e-12 });
+  });
+});
+
+describe('BufferGeometry position buffer — lay-flat invariant', () => {
+  test('rotation + recenter leaves `mesh.geometry.attributes.position` UNCHANGED', () => {
+    // The critical invariant from PR #29, restated as issue #32's ninth AC:
+    // "mesh.geometry.attributes.position values UNCHANGED before and after
+    // lay-flat (proven by test walking the buffer)."
+    const { group, mesh } = buildGroupWithBox();
+    const posAttr = mesh.geometry.getAttribute('position');
+    const before = Float32Array.from(posAttr.array as ArrayLike<number>);
+
+    // Simulate a full lay-flat: compose a rotation, recenter.
+    group.quaternion.premultiply(
+      quaternionToAlignFaceDown(new Vector3(1, 0, 0)),
+    );
+    recenterGroup(group, mesh);
+
+    // And a second one (compose chaining).
+    group.quaternion.premultiply(
+      quaternionToAlignFaceDown(new Vector3(0, 0, 1)),
+    );
+    recenterGroup(group, mesh);
+
+    // Finally a reset.
+    resetOrientation(group, mesh);
+
+    const after = Float32Array.from(posAttr.array as ArrayLike<number>);
+    // Walk the buffer element-by-element. ANY drift in the array would
+    // mean the code accidentally mutated the geometry.
+    expect(after.length).toBe(before.length);
+    for (let i = 0; i < before.length; i++) {
+      // Exact equality: not a tolerance compare. The vertex buffer must
+      // be bit-identical — nothing is supposed to touch it.
+      expect(after[i]).toBe(before[i]);
+    }
+  });
+});
+
+describe('localNormalToWorld', () => {
+  test('returns the same normal when the group is identity', () => {
+    const { group, mesh } = buildGroupWithBox();
+    group.updateMatrixWorld(true);
+    const worldN = localNormalToWorld(mesh, new Vector3(1, 0, 0));
+    expect({ x: worldN.x, y: worldN.y, z: worldN.z }).toEqualWithTolerance(
+      { x: 1, y: 0, z: 0 },
+      { abs: 1e-6 },
+    );
+  });
+
+  test('applies the group rotation correctly', () => {
+    const { group, mesh } = buildGroupWithBox();
+    // Rotate the group 90° around +Z — local +X maps to world +Y.
+    group.quaternion.setFromAxisAngle(new Vector3(0, 0, 1), Math.PI / 2);
+    group.updateMatrixWorld(true);
+    const worldN = localNormalToWorld(mesh, new Vector3(1, 0, 0));
+    expect({ x: worldN.x, y: worldN.y, z: worldN.z }).toEqualWithTolerance(
+      { x: 0, y: 1, z: 0 },
+      { abs: 1e-6 },
+    );
+  });
+
+  test('ignores a pure translation on the group (normals are direction-only)', () => {
+    const { group, mesh } = buildGroupWithBox();
+    group.position.set(100, 200, 300);
+    group.updateMatrixWorld(true);
+    const worldN = localNormalToWorld(mesh, new Vector3(0, 1, 0));
+    expect({ x: worldN.x, y: worldN.y, z: worldN.z }).toEqualWithTolerance(
+      { x: 0, y: 1, z: 0 },
+      { abs: 1e-6 },
+    );
+  });
+});
+
+describe('issue #32 AC — `quaternionToAlignFaceDown` edge cases', () => {
+  // Dedicated block mirroring the exact wording of the AC checklist so
+  // qa-engineer can map each test to its acceptance bullet at a glance.
+
+  test('AC: `quaternionToAlignFaceDown(new Vector3(0, 1, 0))` rotates (0,1,0) → (0,-1,0)', () => {
+    const q = quaternionToAlignFaceDown(new Vector3(0, 1, 0));
+    const out = rotate(new Vector3(0, 1, 0), q);
+    expect(out.y).toEqualWithTolerance(-1, { abs: 1e-6 });
+    // And the orthogonal components remain zero (the rotation axis lies in XZ).
+    expect(Math.abs(out.x) + Math.abs(out.z)).toBeLessThan(1e-6);
+  });
+
+  test('AC: `quaternionToAlignFaceDown(new Vector3(1, 0, 0))` rotates X → -Y', () => {
+    const q = quaternionToAlignFaceDown(new Vector3(1, 0, 0));
+    const out = rotate(new Vector3(1, 0, 0), q);
+    expect({ x: out.x, y: out.y, z: out.z }).toEqualWithTolerance(
+      { x: 0, y: -1, z: 0 },
+      { abs: 1e-6 },
+    );
+  });
+
+  test('AC: `quaternionToAlignFaceDown(new Vector3(0, -1, 0))` is ≈ identity', () => {
+    const q = quaternionToAlignFaceDown(new Vector3(0, -1, 0));
+    // |q - identity| in quaternion space under tolerance.
+    expect(q.w).toEqualWithTolerance(1, { abs: 1e-6 });
+    expect(Math.hypot(q.x, q.y, q.z)).toBeLessThan(1e-6);
+  });
+});

--- a/tests/renderer/scene/layFlat.test.ts
+++ b/tests/renderer/scene/layFlat.test.ts
@@ -22,6 +22,8 @@
 
 import {
   BoxGeometry,
+  BufferAttribute,
+  BufferGeometry,
   Box3,
   Group,
   Mesh,
@@ -32,6 +34,7 @@ import {
 import { describe, expect, test } from 'vitest';
 
 import {
+  computeWorldBoxTight,
   localNormalToWorld,
   quaternionToAlignFaceDown,
   recenterGroup,
@@ -291,5 +294,177 @@ describe('issue #32 AC — `quaternionToAlignFaceDown` edge cases', () => {
     // |q - identity| in quaternion space under tolerance.
     expect(q.w).toEqualWithTolerance(1, { abs: 1e-6 });
     expect(Math.hypot(q.x, q.y, q.z)).toBeLessThan(1e-6);
+  });
+});
+
+describe('localNormalToWorld — non-uniform scale regression', () => {
+  // QA follow-up from PR #34 round 1: pin the invariant that a local
+  // normal transformed under a non-uniform-scale parent returns the TRUE
+  // world normal (inverse-transpose), not the forward-transform. The
+  // Master group in production today only carries rotation + translation,
+  // but a future mirror / display-scale feature would regress silently
+  // without this test.
+
+  test('applies the inverse-transpose (normal matrix) under non-uniform parent scale', () => {
+    // Build a mesh with a diagonal face normal (1, 1, 0)/√2 — picked
+    // because the correct and incorrect results differ clearly under
+    // `scale.set(2, 1, 0.5)`.
+    const group = new Group();
+    group.scale.set(2, 1, 0.5);
+    const geom = new BoxGeometry(1, 1, 1);
+    const mesh = new Mesh(geom, new MeshBasicMaterial());
+    group.add(mesh);
+    group.updateMatrixWorld(true);
+
+    const localNormal = new Vector3(1, 1, 0).normalize();
+    const worldN = localNormalToWorld(mesh, localNormal);
+
+    // Under scale (sx, sy, sz), the inverse-transpose is diag(1/sx, 1/sy, 1/sz),
+    // so local (1,1,0)/√2 → (1/2, 1, 0) → normalised (1, 2, 0)/√5.
+    // The naive `transformDirection` path would give (2, 1, 0)/√5 instead.
+    const invSqrt5 = 1 / Math.sqrt(5);
+    expect({ x: worldN.x, y: worldN.y, z: worldN.z }).toEqualWithTolerance(
+      { x: 1 * invSqrt5, y: 2 * invSqrt5, z: 0 },
+      { abs: 1e-6 },
+    );
+    // Unit length.
+    expect(Math.hypot(worldN.x, worldN.y, worldN.z)).toEqualWithTolerance(
+      1,
+      { abs: 1e-6 },
+    );
+  });
+
+  test('still correct under pure rotation (regression — rotation-only must not change)', () => {
+    // Safety net: the fix (switch to full normal matrix) must not
+    // regress the rotation-only path. Same 90°-Z rotation as the
+    // existing `localNormalToWorld` test, but asserted alongside the
+    // non-uniform-scale case so both branches are covered in one spot.
+    const group = new Group();
+    group.quaternion.setFromAxisAngle(new Vector3(0, 0, 1), Math.PI / 2);
+    const geom = new BoxGeometry(1, 1, 1);
+    const mesh = new Mesh(geom, new MeshBasicMaterial());
+    group.add(mesh);
+    group.updateMatrixWorld(true);
+
+    const worldN = localNormalToWorld(mesh, new Vector3(1, 0, 0));
+    expect({ x: worldN.x, y: worldN.y, z: worldN.z }).toEqualWithTolerance(
+      { x: 0, y: 1, z: 0 },
+      { abs: 1e-6 },
+    );
+  });
+});
+
+describe('computeWorldBoxTight', () => {
+  // This helper is the fix for PR #34's windows-e2e blocker: the old
+  // `recenterGroup` used `Box3.setFromObject(mesh)` which — without the
+  // `precise=true` flag — transforms the geometry's local AABB's 8 corners
+  // and unions them. For a non-axis-aligned rotation that over-estimates
+  // the world bbox, leaving the mesh floating above Y=0 after recenter.
+  // `computeWorldBoxTight` walks vertices directly, giving the tight bbox.
+
+  test('matches the conservative box for axis-aligned rotations (180° around X)', () => {
+    // A 180° X-axis rotation maps (x, y, z) → (x, -y, -z). The tight bbox
+    // and the conservative corner-transform bbox are identical in this
+    // case (the AABB corners are themselves the extrema), so both paths
+    // must agree.
+    const { group, mesh } = buildGroupWithBox();
+    group.quaternion.setFromAxisAngle(new Vector3(1, 0, 0), Math.PI);
+    group.updateMatrixWorld(true);
+
+    const tight = computeWorldBoxTight(mesh);
+    const conservative = new Box3().setFromObject(mesh);
+
+    expect(tight.min.x).toEqualWithTolerance(conservative.min.x, { abs: 1e-6 });
+    expect(tight.min.y).toEqualWithTolerance(conservative.min.y, { abs: 1e-6 });
+    expect(tight.min.z).toEqualWithTolerance(conservative.min.z, { abs: 1e-6 });
+    expect(tight.max.x).toEqualWithTolerance(conservative.max.x, { abs: 1e-6 });
+    expect(tight.max.y).toEqualWithTolerance(conservative.max.y, { abs: 1e-6 });
+    expect(tight.max.z).toEqualWithTolerance(conservative.max.z, { abs: 1e-6 });
+  });
+
+  test('is TIGHTER than Box3.setFromObject for an off-diagonal mesh under arbitrary rotation', () => {
+    // Reproduces the PR #34 blocker mechanism: a mesh whose vertex set
+    // does NOT coincide with its AABB corners (a tetrahedron is the
+    // minimal example), rotated by an off-axis angle. The conservative
+    // bbox over-estimates; the tight bbox is strictly smaller.
+    const group = new Group();
+    const geom = new BufferGeometry();
+    // Tetrahedron with vertices inside the unit cube but not at corners.
+    // AABB corners = ±0.5, but no vertex sits AT (±0.5, ±0.5, ±0.5).
+    const verts = new Float32Array([
+      // Triangle 1
+      0.5, 0.0, 0.0,
+      0.0, 0.5, 0.0,
+      0.0, 0.0, 0.5,
+      // Triangle 2
+      0.5, 0.0, 0.0,
+      0.0, 0.0, 0.5,
+      0.0, -0.5, 0.0,
+      // Triangle 3
+      0.0, 0.5, 0.0,
+      -0.5, 0.0, 0.0,
+      0.0, 0.0, 0.5,
+      // Triangle 4
+      -0.5, 0.0, 0.0,
+      0.0, -0.5, 0.0,
+      0.0, 0.0, 0.5,
+    ]);
+    geom.setAttribute('position', new BufferAttribute(verts, 3));
+    geom.computeBoundingBox();
+    const mesh = new Mesh(geom, new MeshBasicMaterial());
+    group.add(mesh);
+    // 45° rotation around Y — off-axis, so the conservative 8-corner
+    // transform over-estimates the rotated-vertex bbox.
+    group.quaternion.setFromAxisAngle(new Vector3(0, 1, 0), Math.PI / 4);
+    group.updateMatrixWorld(true);
+
+    const tight = computeWorldBoxTight(mesh);
+    const conservative = new Box3().setFromObject(mesh);
+
+    // Tight must be contained within conservative, and STRICTLY smaller
+    // in at least one extent (the X or Z axis for a Y-rotation).
+    expect(tight.min.x).toBeGreaterThanOrEqual(conservative.min.x - 1e-9);
+    expect(tight.max.x).toBeLessThanOrEqual(conservative.max.x + 1e-9);
+    expect(tight.min.z).toBeGreaterThanOrEqual(conservative.min.z - 1e-9);
+    expect(tight.max.z).toBeLessThanOrEqual(conservative.max.z + 1e-9);
+    const tightXSize = tight.max.x - tight.min.x;
+    const conservativeXSize = conservative.max.x - conservative.min.x;
+    expect(tightXSize).toBeLessThan(conservativeXSize);
+  });
+
+  test('returns empty Box3 on a mesh with no position attribute', () => {
+    const mesh = new Mesh(new BufferGeometry(), new MeshBasicMaterial());
+    const box = computeWorldBoxTight(mesh);
+    expect(box.isEmpty()).toBe(true);
+  });
+});
+
+describe('issue #32 AC #12 — recenterGroup on arbitrary rotation (tight bbox)', () => {
+  // Direct regression for the windows-e2e blocker: after recenterGroup
+  // on a group with an arbitrary rotation, the TRUE (vertex-walk) world
+  // min.y of the mesh must be ≈ 0 within 1e-4 mm — same tolerance the
+  // E2E spec uses on the real mini-figurine.
+
+  test('arbitrary rotation → vertex-walk world min.y is 0 within 1e-4 mm', () => {
+    const { group, mesh } = buildGroupWithBox();
+    // Compose two rotations that do NOT align with the AABB — this is
+    // the regime where the old `Box3.setFromObject` path left the mesh
+    // floating above zero.
+    const q1 = new Quaternion().setFromAxisAngle(
+      new Vector3(1, 0, 0),
+      Math.PI / 3,
+    );
+    const q2 = new Quaternion().setFromAxisAngle(
+      new Vector3(0, 1, 1).normalize(),
+      Math.PI / 5,
+    );
+    group.quaternion.copy(q1).premultiply(q2);
+
+    recenterGroup(group, mesh);
+
+    // Walk the vertex buffer exactly like the E2E spec does and verify
+    // the minimum world-space Y is 0.
+    const tight = computeWorldBoxTight(mesh);
+    expect(tight.min.y).toEqualWithTolerance(0, { abs: 1e-4 });
   });
 });

--- a/tests/renderer/scene/master.test.ts
+++ b/tests/renderer/scene/master.test.ts
@@ -32,7 +32,7 @@
 // manipulate the Three.js scene graph.
 
 import { readFileSync } from 'node:fs';
-import { Box3, Vector3, type Group, type Mesh } from 'three';
+import { Box3, Quaternion, Vector3, type Group, type Mesh } from 'three';
 import { describe, expect, test } from 'vitest';
 
 import { createScene } from '@/renderer/scene/index';
@@ -270,6 +270,51 @@ describe('setMaster — auto-center on print bed (issue #25)', () => {
       expect(worldCenter.y).toBeGreaterThan(0);
     },
   );
+
+  test('builds a three-mesh-bvh bounds tree on the loaded master (picking prep)', async () => {
+    const scene = createScene();
+    const ab = readFixtureBuffer('unit-cube');
+
+    const result = await setMaster(scene, ab);
+
+    // After setMaster, the master's BufferGeometry should carry a bounds
+    // tree set up by `prepareMeshForPicking`. This guards the issue #32
+    // BVH-setup contract: every loaded master is immediately ready for
+    // accelerated face picking without a separate enable step.
+    const geom = result.mesh.geometry as typeof result.mesh.geometry & {
+      boundsTree?: unknown;
+    };
+    expect(geom.boundsTree).toBeDefined();
+  });
+
+  test('second load after a lay-flat rotation resets group quaternion to identity', async () => {
+    // Issue #32 acceptance: "Load second STL after a lay-flat rotation →
+    // new master loads at identity orientation, not inheriting stale
+    // quaternion." We simulate a lay-flat by manually setting the group's
+    // quaternion to a non-identity rotation before the second setMaster.
+    const scene = createScene();
+    const group = getMasterGroup(scene);
+
+    // First load + pretend a lay-flat rotation was applied.
+    const abFirst = readFixtureBuffer('unit-cube');
+    await setMaster(scene, abFirst);
+    group.quaternion.setFromAxisAngle(new Vector3(1, 0, 0), Math.PI / 3);
+    // Sanity: rotation is non-identity.
+    const identity = new Quaternion();
+    expect(group.quaternion.equals(identity)).toBe(false);
+
+    // Second load — must reset the quaternion.
+    const abSecond = readFixtureBuffer('unit-cube');
+    await setMaster(scene, abSecond);
+
+    // Exactly identity, not just "close to identity".
+    expect({
+      x: group.quaternion.x,
+      y: group.quaternion.y,
+      z: group.quaternion.z,
+      w: group.quaternion.w,
+    }).toEqualWithTolerance({ x: 0, y: 0, z: 0, w: 1 }, { abs: 1e-12 });
+  });
 
   test('issue-25 exact example: bbox [267, 1094, 0]–[300, 1120, 40] → offset (-283.5, -1094, -20)', async () => {
     // The issue acceptance criteria quote a concrete bbox + expected offset.

--- a/tests/renderer/scene/picking.test.ts
+++ b/tests/renderer/scene/picking.test.ts
@@ -1,0 +1,255 @@
+// tests/renderer/scene/picking.test.ts
+//
+// Unit tests for the BVH-backed face picker in
+// `src/renderer/scene/picking.ts`.
+//
+// Tests exercise:
+//   - `installAcceleratedRaycast` is idempotent and installs the
+//     `three-mesh-bvh` monkey-patches on `Mesh.prototype` and
+//     `BufferGeometry.prototype`.
+//   - `prepareMeshForPicking` builds a BVH on the mesh (i.e.
+//     `geometry.boundsTree` becomes defined) and `releaseMeshPicking`
+//     disposes it.
+//   - `pickFaceUnderPointer` returns the expected hit when the pointer
+//     aims at a known triangle — on the unit cube fixture, looking
+//     straight down at its top face from +Y should pick a triangle
+//     whose local normal is (0, 1, 0).
+//   - `pickFaceUnderPointer` returns null when the ray misses the mesh.
+//
+// The test builds a real `Mesh` from a canonical fixture (unit-cube) plus
+// an off-center camera so we can assert a non-trivial pick. A headless
+// DOM doesn't help us here — we mock `getBoundingClientRect` on a plain
+// HTMLCanvasElement-like stub because Vitest's `node` environment has no
+// `document`.
+
+import {
+  BufferAttribute,
+  BufferGeometry,
+  Mesh,
+  MeshBasicMaterial,
+  PerspectiveCamera,
+  Vector3,
+} from 'three';
+import { describe, expect, test } from 'vitest';
+
+import {
+  installAcceleratedRaycast,
+  pickFaceUnderPointer,
+  prepareMeshForPicking,
+  releaseMeshPicking,
+} from '@/renderer/scene/picking';
+import { loadFixture } from '@fixtures/meshes/loader';
+
+/**
+ * Build a tiny HTMLCanvasElement-shaped stub that satisfies the subset
+ * of the DOM API `pickFaceUnderPointer` consumes (just
+ * `getBoundingClientRect`). Returns a 1280×800 canvas at (0, 0).
+ */
+function makeCanvasStub(width = 1280, height = 800): HTMLCanvasElement {
+  return {
+    getBoundingClientRect(): DOMRect {
+      return {
+        left: 0,
+        top: 0,
+        right: width,
+        bottom: height,
+        width,
+        height,
+        x: 0,
+        y: 0,
+        toJSON(): unknown {
+          return {};
+        },
+      } as DOMRect;
+    },
+  } as unknown as HTMLCanvasElement;
+}
+
+/**
+ * Build a unit-cube Mesh from the `unit-cube` fixture. Non-indexed,
+ * matches the shape `manifoldToBufferGeometry` emits.
+ */
+async function buildUnitCubeMesh(): Promise<Mesh> {
+  const fixture = await loadFixture('unit-cube');
+  const geom = new BufferGeometry();
+  geom.setAttribute(
+    'position',
+    new BufferAttribute(fixture.geometry.positions, 3),
+  );
+  // Emulate what the adapter would do — fresh normals from winding.
+  geom.computeVertexNormals();
+  const mat = new MeshBasicMaterial();
+  return new Mesh(geom, mat);
+}
+
+describe('installAcceleratedRaycast', () => {
+  test('patches Mesh.prototype.raycast (idempotent)', () => {
+    installAcceleratedRaycast();
+    installAcceleratedRaycast(); // must not throw / re-patch
+    const raycast = (Mesh.prototype as unknown as { raycast: unknown })
+      .raycast;
+    expect(typeof raycast).toBe('function');
+    // Second call — function reference is stable.
+    const raycast2 = (Mesh.prototype as unknown as { raycast: unknown })
+      .raycast;
+    expect(raycast2).toBe(raycast);
+  });
+
+  test('patches BufferGeometry.prototype.computeBoundsTree', () => {
+    installAcceleratedRaycast();
+    const compute = (
+      BufferGeometry.prototype as unknown as {
+        computeBoundsTree?: unknown;
+      }
+    ).computeBoundsTree;
+    expect(typeof compute).toBe('function');
+  });
+});
+
+describe('prepareMeshForPicking + releaseMeshPicking', () => {
+  test('builds and disposes the bounds tree on a cube', async () => {
+    const mesh = await buildUnitCubeMesh();
+    prepareMeshForPicking(mesh);
+    const geom = mesh.geometry as BufferGeometry & { boundsTree?: unknown };
+    expect(geom.boundsTree).toBeTruthy();
+    releaseMeshPicking(mesh);
+    // `disposeBoundsTree` sets `boundsTree` to `null` (not `undefined`),
+    // but either outcome means "no tree present" — assert via falsy.
+    expect(geom.boundsTree ?? null).toBeNull();
+  });
+
+  test('releaseMeshPicking is a no-op on a mesh that never had a tree', async () => {
+    const mesh = await buildUnitCubeMesh();
+    // Do NOT call prepareMeshForPicking. Release must still work without
+    // throwing — matches the disposeMesh path in master.ts.
+    expect(() => releaseMeshPicking(mesh)).not.toThrow();
+  });
+
+  test('prepareMeshForPicking on a mesh with an existing tree rebuilds it', async () => {
+    const mesh = await buildUnitCubeMesh();
+    prepareMeshForPicking(mesh);
+    const geom = mesh.geometry as BufferGeometry & { boundsTree?: unknown };
+    const first = geom.boundsTree;
+    prepareMeshForPicking(mesh);
+    const second = geom.boundsTree;
+    // The tree is a NEW instance (we dispose + rebuild).
+    expect(second).toBeDefined();
+    expect(second).not.toBe(first);
+  });
+});
+
+describe('pickFaceUnderPointer', () => {
+  test('picks a face whose world-normal points up (+Y) when looking down at the cube', async () => {
+    const mesh = await buildUnitCubeMesh();
+    prepareMeshForPicking(mesh);
+    mesh.updateMatrixWorld(true);
+
+    // Camera looking straight down the -Y axis at the cube's top face.
+    const camera = new PerspectiveCamera(45, 1280 / 800, 0.01, 100);
+    camera.position.set(0, 5, 0);
+    camera.up.set(0, 0, -1); // up-vector perpendicular to view — standard trick.
+    camera.lookAt(0, 0, 0);
+    camera.updateMatrixWorld(true);
+    camera.updateProjectionMatrix();
+
+    const canvas = makeCanvasStub(1280, 800);
+    // Point the cursor at the canvas center — NDC (0, 0). With the camera
+    // looking straight down, the ray hits the cube's top face at (0,0.5,0).
+    const pick = pickFaceUnderPointer(
+      { clientX: 640, clientY: 400 },
+      canvas,
+      camera,
+      mesh,
+    );
+
+    expect(pick).not.toBeNull();
+    if (!pick) return;
+    // Top face normal in world space: (0, 1, 0). Since mesh has identity
+    // world transform, local and world normals match.
+    expect({ x: pick.worldNormal.x, y: pick.worldNormal.y, z: pick.worldNormal.z })
+      .toEqualWithTolerance({ x: 0, y: 1, z: 0 }, { abs: 1e-4 });
+    // Hit point must be on the top face (y ≈ 0.5).
+    expect(pick.point.y).toEqualWithTolerance(0.5, { abs: 1e-4 });
+    // faceIndex is a non-negative integer into the mesh's triangles.
+    expect(Number.isInteger(pick.faceIndex)).toBe(true);
+    expect(pick.faceIndex).toBeGreaterThanOrEqual(0);
+    expect(pick.faceIndex).toBeLessThan(12); // unit-cube = 12 tris
+  });
+
+  test('returns null when the pointer misses the mesh', async () => {
+    const mesh = await buildUnitCubeMesh();
+    prepareMeshForPicking(mesh);
+    mesh.updateMatrixWorld(true);
+
+    const camera = new PerspectiveCamera(45, 1280 / 800, 0.01, 100);
+    camera.position.set(0, 5, 0);
+    camera.up.set(0, 0, -1);
+    camera.lookAt(0, 0, 0);
+    camera.updateMatrixWorld(true);
+    camera.updateProjectionMatrix();
+
+    const canvas = makeCanvasStub(1280, 800);
+    // Aim at a corner well outside the cube's projected footprint. At
+    // a 45° FOV with the camera 5 mm away, the near corner of the 1×1×1
+    // cube spans roughly ±11% of the screen height; clientY = 10
+    // (top-edge) is far outside.
+    const pick = pickFaceUnderPointer(
+      { clientX: 0, clientY: 10 },
+      canvas,
+      camera,
+      mesh,
+    );
+    expect(pick).toBeNull();
+  });
+
+  test('returns null on a zero-size canvas', async () => {
+    const mesh = await buildUnitCubeMesh();
+    prepareMeshForPicking(mesh);
+    const camera = new PerspectiveCamera(45, 1, 0.01, 100);
+    const canvas = makeCanvasStub(0, 0);
+    const pick = pickFaceUnderPointer(
+      { clientX: 10, clientY: 10 },
+      canvas,
+      camera,
+      mesh,
+    );
+    expect(pick).toBeNull();
+  });
+});
+
+describe('pickFaceUnderPointer under a rotated group', () => {
+  test('world normal reflects the group rotation', async () => {
+    // Parent the mesh under a Group rotated 90° around +X so the local
+    // +Y face now points to +Z in world space. A camera aimed from +Z
+    // at the rotated top face must report a world normal of (0, 0, 1).
+    const mesh = await buildUnitCubeMesh();
+    prepareMeshForPicking(mesh);
+
+    const { Group } = await import('three');
+    const group = new Group();
+    group.add(mesh);
+    group.quaternion.setFromAxisAngle(new Vector3(1, 0, 0), Math.PI / 2);
+    group.updateMatrixWorld(true);
+
+    const camera = new PerspectiveCamera(45, 1280 / 800, 0.01, 100);
+    camera.position.set(0, 0, 5);
+    camera.lookAt(0, 0, 0);
+    camera.updateMatrixWorld(true);
+    camera.updateProjectionMatrix();
+
+    const canvas = makeCanvasStub(1280, 800);
+    const pick = pickFaceUnderPointer(
+      { clientX: 640, clientY: 400 },
+      canvas,
+      camera,
+      mesh,
+    );
+    expect(pick).not.toBeNull();
+    if (!pick) return;
+    // World-space normal is (0, 0, 1) — the local +Y after the group
+    // rotation. Tolerance is looser than above because the rotation
+    // brings floating-point subtleties into play.
+    expect({ x: pick.worldNormal.x, y: pick.worldNormal.y, z: pick.worldNormal.z })
+      .toEqualWithTolerance({ x: 0, y: 0, z: 1 }, { abs: 1e-4 });
+  });
+});

--- a/tests/visual/scene-rotated-mini-figurine.spec.ts
+++ b/tests/visual/scene-rotated-mini-figurine.spec.ts
@@ -1,10 +1,8 @@
 // tests/visual/scene-rotated-mini-figurine.spec.ts
 //
 // Visual regression: mini-figurine loaded as master, rotated by a
-// known quaternion via the viewport test-hook, and re-centered via
-// `resetOrientation`-inverse semantics (we don't call `reset` — we
-// apply a rotation and a recenter). Snapshots the post-rotation
-// scene.
+// known quaternion, recentered, and re-framed. Snapshots the
+// post-rotation scene.
 //
 // This golden is advisory for the first 2 weeks per ADR-003 §B (visual
 // regression gating policy). The test is pinned to a synthetic rotation
@@ -12,6 +10,16 @@
 // SwiftShader runs — live picking hits floating-point raycast drift
 // which makes the pick coordinate non-deterministic at sub-millimetre
 // scales.
+//
+// We reach the Master group through `window.__testHooks.scene` (exposed
+// by `viewport.ts` under BUILD_TIME_TEST) and mutate its quaternion
+// directly. The post-rotation auto-center + camera re-frame is driven
+// by the existing `viewport.setMaster` → `frameToBox3` pipeline; for
+// the rotation-compose specifically we reuse the master group's own
+// `Quaternion` instance (reading Three.js types off the scene graph
+// instead of importing the module inside the page — bare-specifier
+// imports like `import 'three'` inside `page.evaluate` do not resolve
+// in Chromium's page context and would hard-fail this spec).
 
 import { expect, test } from '@playwright/test';
 import { readFileSync } from 'node:fs';
@@ -60,7 +68,8 @@ test.describe('visual — scene with rotated master (lay-flat)', () => {
     const fixtureBytes = readFileSync(FIXTURE_PATH);
     const byteArray = Array.from(fixtureBytes);
 
-    // Load the master.
+    // Load the master via the public test-hook API (same path as
+    // `scene-with-mini-figurine.spec.ts`).
     await page.evaluate(async (bytes: number[]) => {
       const u8 = new Uint8Array(bytes);
       const ab = u8.buffer.slice(u8.byteOffset, u8.byteOffset + u8.byteLength);
@@ -77,44 +86,57 @@ test.describe('visual — scene with rotated master (lay-flat)', () => {
       await hooks.viewport.setMaster(ab);
     }, byteArray);
 
-    // Apply a synthetic lay-flat: rotate the master group 90° around +X
-    // via a pure Quaternion (avoids live-pick nondeterminism) and call
-    // the viewport's resetOrientation-adjacent path. Actually, the
-    // cleanest + deterministic sequence is:
-    //   1. Set group.quaternion to a fixed rotation.
-    //   2. Re-apply auto-center (we can call recenterGroup indirectly by
-    //      triggering a re-frame via the viewport's camera helper, but the
-    //      viewport doesn't expose that — instead, we read the internals
-    //      through the test-hook scene reference and do it manually).
+    // Apply a synthetic lay-flat: 90° rotation around +X. We reach the
+    // Master group by scanning `scene.children` for the `userData.tag`
+    // marker (set by `createScene()` / honoured by `setMaster`).
     //
-    // We keep this minimal: rotate + recenter + re-frame the camera at
-    // the new world AABB.
+    // The key trick: to avoid `import 'three'` (bare specifiers don't
+    // resolve in Chromium's page context), we read Three.js types off
+    // the scene graph itself. `group.quaternion` is a Three `Quaternion`
+    // instance — `.constructor` gets us the class so we can allocate
+    // a fresh rotation without importing the module. Likewise for
+    // `Vector3` via `camera.position.constructor`.
     await page.evaluate(() => {
-      type ThreeNS = {
-        Quaternion: new () => { setFromAxisAngle: (axis: unknown, angle: number) => void };
-        Vector3: new (x?: number, y?: number, z?: number) => unknown;
-        Box3: new () => { setFromObject: (o: unknown) => { min: { y: number }; getCenter: (out: unknown) => unknown } };
+      type QuaternionLike = {
+        setFromAxisAngle: (axis: unknown, angle: number) => unknown;
       };
+      type QuaternionCtor = new () => QuaternionLike;
+      type Vec3Like = { x: number; y: number; z: number };
+      type Vec3Ctor = new (x?: number, y?: number, z?: number) => Vec3Like;
       type GroupLike = {
         userData?: Record<string, unknown>;
         quaternion: {
-          copy: (q: unknown) => void;
-          setFromAxisAngle: (axis: unknown, angle: number) => void;
+          constructor: QuaternionCtor;
+          copy: (q: unknown) => unknown;
+          setFromAxisAngle: (axis: unknown, angle: number) => unknown;
         };
-        position: { set: (x: number, y: number, z: number) => void };
+        position: {
+          constructor: Vec3Ctor;
+          set: (x: number, y: number, z: number) => void;
+        };
         updateMatrixWorld: (force: boolean) => void;
-        children: Array<{ updateMatrixWorld: (f: boolean) => void }>;
       };
       type MeshLike = {
         userData?: Record<string, unknown>;
         type?: string;
-        updateMatrixWorld: (f: boolean) => void;
+        geometry: {
+          getAttribute: (
+            n: string,
+          ) => { count: number; array: ArrayLike<number> };
+        };
+        matrixWorld: { elements: ArrayLike<number> };
+        updateWorldMatrix: (parents: boolean, children: boolean) => void;
       };
-      type ControlsLike = { target: { copy: (v: unknown) => void }; update: () => void };
+      type ControlsLike = {
+        target: { set: (x: number, y: number, z: number) => void };
+        update: () => void;
+      };
       type CameraLike = {
-        position: { copy: (v: unknown) => void; addScaledVector: (v: unknown, s: number) => void };
-        lookAt: (x: unknown, y?: number, z?: number) => void;
+        position: {
+          set: (x: number, y: number, z: number) => void;
+        };
         up: { set: (x: number, y: number, z: number) => void };
+        lookAt: (x: number, y: number, z: number) => void;
         updateProjectionMatrix: () => void;
         updateMatrixWorld: () => void;
       };
@@ -142,57 +164,102 @@ test.describe('visual — scene with rotated master (lay-flat)', () => {
         if (o.userData?.['tag'] === 'master' && o.type === 'Mesh') mesh = o;
       });
       if (!mesh) throw new Error('master mesh missing');
+      const foundMesh = mesh as MeshLike;
 
-      // Dynamically grab the module's Three constructors via a small probe:
-      // every loaded mesh carries `.geometry` which in turn has a
-      // `.constructor` that is Three's `BufferGeometry`. Walk back to
-      // `BufferGeometry.prototype.constructor` to find the nearest module
-      // reference. That's brittle — simpler to import via dynamic import.
-      return import('three').then((THREE) => {
-        const T = THREE as unknown as ThreeNS;
-        const q = new T.Quaternion();
-        q.setFromAxisAngle(new T.Vector3(1, 0, 0), Math.PI / 2);
-        group.quaternion.copy(q);
-        // Zero the position, update world, read bbox, re-center so min.y = 0.
-        group.position.set(0, 0, 0);
-        group.updateMatrixWorld(true);
+      // Pull the Three constructors off existing scene-graph instances so we
+      // don't have to import the module inside the page (bare specifiers
+      // don't resolve in the browser).
+      const QuatCtor = group.quaternion.constructor;
+      const Vec3Ctor = group.position.constructor;
 
-        const box = new T.Box3().setFromObject(mesh as unknown as object);
-        const center = new T.Vector3();
-        (box as unknown as { getCenter: (out: unknown) => unknown }).getCenter(
-          center,
-        );
-        const cx = (center as unknown as { x: number; y: number; z: number }).x;
-        const cz = (center as unknown as { x: number; y: number; z: number }).z;
-        const minY = box.min.y;
-        group.position.set(-cx, -minY, -cz);
-        group.updateMatrixWorld(true);
+      const xAxis = new Vec3Ctor(1, 0, 0);
+      const q = new QuatCtor();
+      q.setFromAxisAngle(xAxis, Math.PI / 2);
+      group.quaternion.copy(q);
 
-        // Re-frame the camera to the new world AABB.
-        const box2 = new T.Box3().setFromObject(mesh as unknown as object);
-        const center2 = new T.Vector3();
-        (box2 as unknown as { getCenter: (out: unknown) => unknown }).getCenter(
-          center2,
-        );
-        const size = new T.Vector3();
-        (box2 as unknown as { getSize: (out: unknown) => unknown }).getSize(
-          size,
-        );
-        const s = size as unknown as { x: number; y: number; z: number };
-        const maxDim = Math.max(s.x, s.y, s.z, 1e-3);
-        const fovRad = (45 * Math.PI) / 180;
-        const distance = (maxDim / 2 / Math.tan(fovRad / 2)) * 1.4;
-        const dir = new T.Vector3(1, 1, 1);
-        (dir as unknown as { normalize: () => unknown }).normalize();
-        vp.camera.position.copy(center2);
-        vp.camera.position.addScaledVector(dir, distance);
-        vp.camera.up.set(0, 1, 0);
-        vp.camera.lookAt(center2);
-        vp.camera.updateProjectionMatrix();
-        vp.camera.updateMatrixWorld();
-        vp.controls.target.copy(center2);
-        vp.controls.update();
-      });
+      // Zero the position, update world, compute tight world bbox by
+      // walking the mesh's vertex buffer, then re-center so min.y = 0 and
+      // xz-center = 0. Tight vertex walk (not the conservative corner
+      // transform of `Box3.setFromObject`) matches the runtime lay-flat
+      // recenter path.
+      group.position.set(0, 0, 0);
+      group.updateMatrixWorld(true);
+      foundMesh.updateWorldMatrix(true, false);
+
+      const e = foundMesh.matrixWorld.elements;
+      const attr = foundMesh.geometry.getAttribute('position');
+      const arr = attr.array;
+      let minX = Infinity;
+      let maxX = -Infinity;
+      let minY = Infinity;
+      let maxY = -Infinity;
+      let minZ = Infinity;
+      let maxZ = -Infinity;
+      for (let i = 0; i < attr.count; i++) {
+        const lx = arr[i * 3]!;
+        const ly = arr[i * 3 + 1]!;
+        const lz = arr[i * 3 + 2]!;
+        const wx = e[0]! * lx + e[4]! * ly + e[8]! * lz + e[12]!;
+        const wy = e[1]! * lx + e[5]! * ly + e[9]! * lz + e[13]!;
+        const wz = e[2]! * lx + e[6]! * ly + e[10]! * lz + e[14]!;
+        if (wx < minX) minX = wx;
+        if (wx > maxX) maxX = wx;
+        if (wy < minY) minY = wy;
+        if (wy > maxY) maxY = wy;
+        if (wz < minZ) minZ = wz;
+        if (wz > maxZ) maxZ = wz;
+      }
+      const cx = (minX + maxX) / 2;
+      const cz = (minZ + maxZ) / 2;
+      group.position.set(-cx, -minY, -cz);
+      group.updateMatrixWorld(true);
+      foundMesh.updateWorldMatrix(true, false);
+
+      // Re-frame the camera to the post-recenter world AABB. We recompute
+      // the bbox after the translation so the numbers are accurate.
+      const e2 = foundMesh.matrixWorld.elements;
+      minX = Infinity;
+      maxX = -Infinity;
+      minY = Infinity;
+      maxY = -Infinity;
+      minZ = Infinity;
+      maxZ = -Infinity;
+      for (let i = 0; i < attr.count; i++) {
+        const lx = arr[i * 3]!;
+        const ly = arr[i * 3 + 1]!;
+        const lz = arr[i * 3 + 2]!;
+        const wx = e2[0]! * lx + e2[4]! * ly + e2[8]! * lz + e2[12]!;
+        const wy = e2[1]! * lx + e2[5]! * ly + e2[9]! * lz + e2[13]!;
+        const wz = e2[2]! * lx + e2[6]! * ly + e2[10]! * lz + e2[14]!;
+        if (wx < minX) minX = wx;
+        if (wx > maxX) maxX = wx;
+        if (wy < minY) minY = wy;
+        if (wy > maxY) maxY = wy;
+        if (wz < minZ) minZ = wz;
+        if (wz > maxZ) maxZ = wz;
+      }
+      const centerX = (minX + maxX) / 2;
+      const centerY = (minY + maxY) / 2;
+      const centerZ = (minZ + maxZ) / 2;
+      const sizeX = maxX - minX;
+      const sizeY = maxY - minY;
+      const sizeZ = maxZ - minZ;
+      const maxDim = Math.max(sizeX, sizeY, sizeZ, 1e-3);
+      const fovRad = (45 * Math.PI) / 180;
+      const distance = (maxDim / 2 / Math.tan(fovRad / 2)) * 1.4;
+      // Normalised (1,1,1) direction. √3 ≈ 1.7320508.
+      const invSqrt3 = 1 / Math.sqrt(3);
+      vp.camera.position.set(
+        centerX + distance * invSqrt3,
+        centerY + distance * invSqrt3,
+        centerZ + distance * invSqrt3,
+      );
+      vp.camera.up.set(0, 1, 0);
+      vp.camera.lookAt(centerX, centerY, centerZ);
+      vp.camera.updateProjectionMatrix();
+      vp.camera.updateMatrixWorld();
+      vp.controls.target.set(centerX, centerY, centerZ);
+      vp.controls.update();
     });
 
     await page.clock.runFor(100);

--- a/tests/visual/scene-rotated-mini-figurine.spec.ts
+++ b/tests/visual/scene-rotated-mini-figurine.spec.ts
@@ -1,0 +1,207 @@
+// tests/visual/scene-rotated-mini-figurine.spec.ts
+//
+// Visual regression: mini-figurine loaded as master, rotated by a
+// known quaternion via the viewport test-hook, and re-centered via
+// `resetOrientation`-inverse semantics (we don't call `reset` — we
+// apply a rotation and a recenter). Snapshots the post-rotation
+// scene.
+//
+// This golden is advisory for the first 2 weeks per ADR-003 §B (visual
+// regression gating policy). The test is pinned to a synthetic rotation
+// (not a live BVH-driven pick) so the output is deterministic across
+// SwiftShader runs — live picking hits floating-point raycast drift
+// which makes the pick coordinate non-deterministic at sub-millimetre
+// scales.
+
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const RENDERER_URL = 'http://localhost:5174/?test=1';
+const FIXTURE_PATH = resolve(
+  __dirname,
+  '..',
+  'fixtures',
+  'meshes',
+  'mini-figurine.stl',
+);
+
+test.describe('visual — scene with rotated master (lay-flat)', () => {
+  test('renders mini-figurine after a synthetic 90°X rotation + recenter', async ({
+    page,
+  }) => {
+    await page.clock.install({ time: new Date('2026-04-18T00:00:00Z') });
+
+    await page.addInitScript(() => {
+      (window as unknown as { api: Record<string, unknown> }).api = {
+        getVersion: () => Promise.resolve('0.0.0'),
+        openStl: () => Promise.resolve({ canceled: true }),
+        saveStl: () => Promise.resolve({ canceled: true }),
+      };
+    });
+
+    await page.goto(RENDERER_URL);
+
+    await page.waitForFunction(
+      () => {
+        const hooks = (
+          window as unknown as {
+            __testHooks?: { viewportReady?: boolean };
+          }
+        ).__testHooks;
+        if (hooks?.viewportReady) return true;
+        const container = document.getElementById('viewport');
+        return !!container?.querySelector('canvas');
+      },
+      undefined,
+      { timeout: 10_000 },
+    );
+
+    const fixtureBytes = readFileSync(FIXTURE_PATH);
+    const byteArray = Array.from(fixtureBytes);
+
+    // Load the master.
+    await page.evaluate(async (bytes: number[]) => {
+      const u8 = new Uint8Array(bytes);
+      const ab = u8.buffer.slice(u8.byteOffset, u8.byteOffset + u8.byteLength);
+      const hooks = (
+        window as unknown as {
+          __testHooks?: {
+            viewport?: { setMaster: (buf: ArrayBuffer) => Promise<unknown> };
+          };
+        }
+      ).__testHooks;
+      if (!hooks?.viewport) {
+        throw new Error('viewport test hook missing');
+      }
+      await hooks.viewport.setMaster(ab);
+    }, byteArray);
+
+    // Apply a synthetic lay-flat: rotate the master group 90° around +X
+    // via a pure Quaternion (avoids live-pick nondeterminism) and call
+    // the viewport's resetOrientation-adjacent path. Actually, the
+    // cleanest + deterministic sequence is:
+    //   1. Set group.quaternion to a fixed rotation.
+    //   2. Re-apply auto-center (we can call recenterGroup indirectly by
+    //      triggering a re-frame via the viewport's camera helper, but the
+    //      viewport doesn't expose that — instead, we read the internals
+    //      through the test-hook scene reference and do it manually).
+    //
+    // We keep this minimal: rotate + recenter + re-frame the camera at
+    // the new world AABB.
+    await page.evaluate(() => {
+      type ThreeNS = {
+        Quaternion: new () => { setFromAxisAngle: (axis: unknown, angle: number) => void };
+        Vector3: new (x?: number, y?: number, z?: number) => unknown;
+        Box3: new () => { setFromObject: (o: unknown) => { min: { y: number }; getCenter: (out: unknown) => unknown } };
+      };
+      type GroupLike = {
+        userData?: Record<string, unknown>;
+        quaternion: {
+          copy: (q: unknown) => void;
+          setFromAxisAngle: (axis: unknown, angle: number) => void;
+        };
+        position: { set: (x: number, y: number, z: number) => void };
+        updateMatrixWorld: (force: boolean) => void;
+        children: Array<{ updateMatrixWorld: (f: boolean) => void }>;
+      };
+      type MeshLike = {
+        userData?: Record<string, unknown>;
+        type?: string;
+        updateMatrixWorld: (f: boolean) => void;
+      };
+      type ControlsLike = { target: { copy: (v: unknown) => void }; update: () => void };
+      type CameraLike = {
+        position: { copy: (v: unknown) => void; addScaledVector: (v: unknown, s: number) => void };
+        lookAt: (x: unknown, y?: number, z?: number) => void;
+        up: { set: (x: number, y: number, z: number) => void };
+        updateProjectionMatrix: () => void;
+        updateMatrixWorld: () => void;
+      };
+      type ViewportHooks = {
+        scene?: {
+          traverse: (cb: (o: MeshLike) => void) => void;
+          children: GroupLike[];
+        };
+        viewport?: { controls: ControlsLike; camera: CameraLike };
+      };
+
+      const hooks = (window as unknown as { __testHooks?: ViewportHooks })
+        .__testHooks;
+      const scene = hooks?.scene;
+      const vp = hooks?.viewport;
+      if (!scene || !vp) throw new Error('hooks missing');
+
+      // Find the master group + mesh.
+      const group = scene.children.find(
+        (c) => c.userData?.['tag'] === 'master',
+      );
+      if (!group) throw new Error('master group missing');
+      let mesh: MeshLike | null = null;
+      scene.traverse((o) => {
+        if (o.userData?.['tag'] === 'master' && o.type === 'Mesh') mesh = o;
+      });
+      if (!mesh) throw new Error('master mesh missing');
+
+      // Dynamically grab the module's Three constructors via a small probe:
+      // every loaded mesh carries `.geometry` which in turn has a
+      // `.constructor` that is Three's `BufferGeometry`. Walk back to
+      // `BufferGeometry.prototype.constructor` to find the nearest module
+      // reference. That's brittle — simpler to import via dynamic import.
+      return import('three').then((THREE) => {
+        const T = THREE as unknown as ThreeNS;
+        const q = new T.Quaternion();
+        q.setFromAxisAngle(new T.Vector3(1, 0, 0), Math.PI / 2);
+        group.quaternion.copy(q);
+        // Zero the position, update world, read bbox, re-center so min.y = 0.
+        group.position.set(0, 0, 0);
+        group.updateMatrixWorld(true);
+
+        const box = new T.Box3().setFromObject(mesh as unknown as object);
+        const center = new T.Vector3();
+        (box as unknown as { getCenter: (out: unknown) => unknown }).getCenter(
+          center,
+        );
+        const cx = (center as unknown as { x: number; y: number; z: number }).x;
+        const cz = (center as unknown as { x: number; y: number; z: number }).z;
+        const minY = box.min.y;
+        group.position.set(-cx, -minY, -cz);
+        group.updateMatrixWorld(true);
+
+        // Re-frame the camera to the new world AABB.
+        const box2 = new T.Box3().setFromObject(mesh as unknown as object);
+        const center2 = new T.Vector3();
+        (box2 as unknown as { getCenter: (out: unknown) => unknown }).getCenter(
+          center2,
+        );
+        const size = new T.Vector3();
+        (box2 as unknown as { getSize: (out: unknown) => unknown }).getSize(
+          size,
+        );
+        const s = size as unknown as { x: number; y: number; z: number };
+        const maxDim = Math.max(s.x, s.y, s.z, 1e-3);
+        const fovRad = (45 * Math.PI) / 180;
+        const distance = (maxDim / 2 / Math.tan(fovRad / 2)) * 1.4;
+        const dir = new T.Vector3(1, 1, 1);
+        (dir as unknown as { normalize: () => unknown }).normalize();
+        vp.camera.position.copy(center2);
+        vp.camera.position.addScaledVector(dir, distance);
+        vp.camera.up.set(0, 1, 0);
+        vp.camera.lookAt(center2);
+        vp.camera.updateProjectionMatrix();
+        vp.camera.updateMatrixWorld();
+        vp.controls.target.copy(center2);
+        vp.controls.update();
+      });
+    });
+
+    await page.clock.runFor(100);
+
+    await expect(page).toHaveScreenshot('scene-rotated-mini-figurine.png', {
+      maxDiffPixelRatio: 0.01,
+      threshold: 0.15,
+      animations: 'disabled',
+      fullPage: false,
+    });
+  });
+});


### PR DESCRIPTION
# Summary

Implements "Place on face" (a.k.a. lay-flat) picking in the viewport
— same interaction as OrcaSlicer / Bambu Studio / Cura. The user
toggles picking mode, hovers to preview a face highlight + normal
overlay, clicks to commit a rotation that lays that face on the bed,
and can reset to the STL-faithful orientation.

Group-level transforms only. `mesh.geometry.attributes.position` and
the paired `Manifold` stay STL-faithful — proven by a dedicated test
that walks the buffer element-by-element across rotation + recenter
+ reset.

## Linked issue

Closes #32

## Acceptance criteria (from the issue)

- [x] Click "Place on face" toggle → cursor becomes crosshair when over mesh; exits toggle on Escape.
- [x] Hovering a face highlights it (accent-blue tint) + flat overlay quad shows normal.
- [x] Click on a face → group rotates so that face's normal points down (-Y); mesh re-sits on Y=0 with XZ center at origin; camera re-frames.
- [x] Reset orientation restores identity quaternion; auto-center re-runs.
- [x] `mesh.geometry.attributes.position` values UNCHANGED before and after lay-flat (proven by test walking the buffer).
- [x] `Manifold` instance is not re-created (cheap viewport rotation only — no kernel round-trip in the lay-flat path).
- [x] Load second STL after a lay-flat rotation → new master loads at identity orientation, not inheriting stale quaternion.
- [x] Unit test: `quaternionToAlignFaceDown(new Vector3(0, 1, 0))` produces a quaternion that rotates `(0,1,0) → (0,-1,0)`.
- [x] Unit test: `quaternionToAlignFaceDown(new Vector3(1, 0, 0))` rotates X → -Y.
- [x] Unit test: `quaternionToAlignFaceDown(new Vector3(0, -1, 0))` is ≈ identity.
- [x] Unit test: `recenterGroup(group, mesh)` called on a group with a non-identity quaternion correctly centers the rotated world-space bbox.
- [x] Unit test: picking on the unit-cube fixture at a known screen position returns the expected face index + world normal.
- [x] Playwright E2E: load mini-figurine → synthesise click at canvas center with camera aimed straight down → assert world bbox min.y ≈ 0 (1e-4 mm).
- [x] Playwright visual: snapshot of rotated-mini-figurine — new golden file.

## What I did

- New `src/renderer/scene/layFlat.ts` — pure math: `quaternionToAlignFaceDown`, `recenterGroup`, `resetOrientation`, `localNormalToWorld`.
- New `src/renderer/scene/picking.ts` — three-mesh-bvh monkey-patch installer (idempotent), `prepareMeshForPicking` / `releaseMeshPicking`, `pickFaceUnderPointer`.
- New `src/renderer/scene/layFlatController.ts` — orchestrator: hover highlight (triangle outline + normal quad), click-to-commit with `premultiply` compose, Escape-exit, auto-exit-on-commit. Emits `lay-flat-active-changed` CustomEvent.
- New `src/renderer/ui/placeOnFaceToggle.ts` — the toggle + reset buttons. Pressed-state styled, `aria-pressed` mirrored.
- Modified `src/renderer/scene/master.ts` — resets `group.quaternion` to identity on each load; builds + disposes the BVH via the new picking helpers. Existing auto-center math preserved bit-identically (local bbox path) so the #25 tolerance stays at 1e-6.
- Modified `src/renderer/scene/viewport.ts` — four new handle methods: `enableFacePicking`, `disableFacePicking`, `isFacePickingActive`, `resetOrientation`. Lay-flat auto-terminates on master swap.
- Modified `src/renderer/main.ts` — wires the toggle into the topbar; listens to the CustomEvent so the button state mirrors the controller.
- Modified `src/renderer/i18n/en.json` + `index.html` — four new `layFlat.*` strings + pressed-state CSS.

## Test results

- [x] `pnpm lint` — green
- [x] `pnpm typecheck` — green
- [x] `pnpm test` — green (106 passed, 1 skipped). New unit tests: 16 in `layFlat.test.ts`, 9 in `picking.test.ts`, 2 added to `master.test.ts`.
- [ ] `pnpm test:e2e` — not run locally (no Electron binary setup on this worktree); expect green on `windows-latest` CI runner.
- [x] New unit tests added for changed geometry / behaviour.
- [x] No STL output in this PR — canonical-SHA-256 snapshots unchanged.

## Screenshots / GIFs

Visual-regression golden `scene-rotated-mini-figurine.png` will be
generated by the CI's `visual` Playwright project (advisory for the
first 2 weeks per ADR-003 §B). No diff to review until the first
green run lands.

## QA sign-off

- [ ] `qa-engineer` reviewed and approved
- [ ] Visual regression diff reviewed — acceptable / intentional

## Checklist

- [x] Units: rotation math is dimensionless; recenter + bbox math is mm internally.
- [x] i18n: all four new strings routed through `i18next` (`layFlat.*` in en.json).
- [x] Secrets: no credentials in diff.
- [x] No new env vars.
- [x] No new runtime deps. `three-mesh-bvh` is already locked (ADR-002).
- [x] CLAUDE.md still accurate — scope is view-layer only, no new mold strategy.

## Diff size note

Source totals ~900 lines across four new files + four touched files
(layFlatController.ts is the largest at 416 lines; much of it is
comment-heavy by the skill convention). This is over the ~600-line
"consider splitting" threshold the issue mentioned, but splitting
now would leave BVH picking half-wired (hover only) without the
payoff of the rotation commit, and the AC specifically tests the
commit path. Single cohesive PR felt better here; happy to slice
in a follow-up if QA prefers.

## Agent attribution

Primary author: `frontend-dev`
Reviewed by: `qa-engineer`