### PR TITLE
feat(ui): Generate-mold button + orientation-committed gate

### DIFF
--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -35,5 +35,11 @@
     "toggleHint": "Click a face on the mesh to lay it flat on the print bed (Esc to cancel)",
     "reset": "Reset orientation",
     "resetHint": "Restore the mesh to its original STL orientation"
+  },
+  "generate": {
+    "button": "Generate mold",
+    "hint": "Orient the part on its base (use Place on face in the toolbar), then click Generate.",
+    "ready": "Ready to generate",
+    "noMaster": "Load an STL to begin."
   }
 }

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -171,6 +171,51 @@
         padding: 0;
         border: none;
       }
+      /* ---- Generate-mold block (issue #36) ------------------------------ */
+      .generate-block {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        padding-bottom: 12px;
+        border-bottom: 1px solid var(--border);
+      }
+      .generate-block__button {
+        width: 100%;
+        padding: 8px 12px;
+        font-size: 13px;
+        font-weight: 600;
+        background: var(--accent);
+        color: #0b0d10;
+        border: 1px solid var(--accent);
+        border-radius: 6px;
+        cursor: pointer;
+        transition: opacity 0.1s ease-out;
+      }
+      .generate-block__button:hover:not(:disabled) {
+        /* Reuse the accent tint; a hover tint is not in the token set */
+        filter: brightness(1.08);
+        border-color: var(--accent);
+      }
+      .generate-block__button:disabled {
+        background: transparent;
+        color: var(--muted);
+        border-color: var(--border);
+        cursor: not-allowed;
+        opacity: 0.7;
+      }
+      .generate-block__button:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+      .generate-block__hint {
+        font-size: 11px;
+        color: var(--muted);
+        line-height: 1.4;
+        margin: 0;
+      }
+      .generate-block__hint--ready {
+        color: var(--accent);
+      }
       .param-field {
         display: flex;
         flex-direction: column;

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -11,13 +11,20 @@
  * tsconfig include).
  */
 
-import { LAY_FLAT_ACTIVE_EVENT } from './scene/layFlatController';
+import {
+  LAY_FLAT_ACTIVE_EVENT,
+  LAY_FLAT_COMMITTED_EVENT,
+} from './scene/layFlatController';
 import { mount, type MountedViewport } from './scene/viewport';
 import { initI18n } from './i18n';
 import {
   createParametersStore,
   type ParametersStore,
 } from './state/parameters';
+import {
+  mountGenerateButton,
+  type GenerateButtonApi,
+} from './ui/generateButton';
 import {
   mountParameterPanel,
   type ParameterPanelApi,
@@ -33,6 +40,7 @@ let viewport: MountedViewport | null = null;
 let parametersStore: ParametersStore | null = null;
 let parameterPanel: ParameterPanelApi | null = null;
 let placeOnFace: PlaceOnFaceToggleApi | null = null;
+let generateButton: GenerateButtonApi | null = null;
 
 async function hydrateVersion(): Promise<void> {
   // The topbar owns the `[data-testid="app-version"]` element now; keep
@@ -123,7 +131,50 @@ function mountParameters(): void {
     return;
   }
   parametersStore = createParametersStore();
+  // Panel mounts first because `mountParameterPanel` does `container.textContent = ''`
+  // to wipe any pre-mount HTML fallback. Mounting the generate-block before
+  // the panel would have it clobbered.
   parameterPanel = mountParameterPanel(container, parametersStore);
+
+  // Mount the Generate-mold block and move it to the TOP of the sidebar
+  // (issue #36: "at the TOP of the right sidebar, above the parameter
+  // form"). `appendChild` followed by `prepend` gives us idempotent top-
+  // insertion regardless of how many children `mountParameterPanel` added.
+  generateButton = mountGenerateButton(container, {
+    onGenerate() {
+      // Issue #36 stub: log the payload. Phase 3c wave-1-geometry (#37)
+      // replaces this with the real `generateSiliconeShell(master,
+      // parameters, viewTransform)` call once that PR lands.
+      //
+      // We look up the master group by its `userData.tag === 'master'`
+      // on the scene root — `createScene()` always seeds this child, and
+      // duplicating the tag literal (instead of importing a constant from
+      // `scene/master.ts`) keeps this module independent of the
+      // master-module internals.
+      const masterGroup = viewport?.scene.children.find(
+        (c) => c.userData['tag'] === 'master',
+      );
+      const q = masterGroup?.quaternion;
+      console.log('[generate] requested', {
+        quaternion: q ? [q.x, q.y, q.z, q.w] : null,
+        parameters: parametersStore?.get() ?? null,
+      });
+      // TODO(phase-3c): replace with `generateSiliconeShell(master, parameters, q)` once #37 merges.
+    },
+  });
+  container.prepend(generateButton.element);
+
+  // Subscribe to orientation-committed transitions. The controller fires
+  // true after a Place-on-face commit, false after Reset orientation, and
+  // false when a new master is loaded. We drive `setEnabled` straight off
+  // the event detail so the button's state is always the controller's
+  // truth — no polling.
+  document.addEventListener(LAY_FLAT_COMMITTED_EVENT, (ev) => {
+    const detail = (ev as CustomEvent<boolean>).detail;
+    if (typeof detail === 'boolean' && generateButton) {
+      generateButton.setEnabled(detail);
+    }
+  });
 
   if (process.env.NODE_ENV === 'test') {
     const w = window as unknown as {
@@ -131,6 +182,7 @@ function mountParameters(): void {
     };
     const hooks = (w.__testHooks ??= {});
     hooks['parameters'] = parametersStore;
+    if (generateButton) hooks['generateButton'] = generateButton;
   }
   // Silence unused-var lint for the panel handle — we need the reference
   // to prevent early GC of its listeners, and to give future shutdown
@@ -195,6 +247,15 @@ async function handleOpenStl(button: HTMLButtonElement): Promise<void> {
     if (placeOnFace) {
       placeOnFace.setEnabled(true);
       placeOnFace.setActive(false);
+    }
+    // Flip the Generate-block's hint from "Load an STL to begin." to
+    // "Orient the part on its base...". The button stays disabled — the
+    // LAY_FLAT_COMMITTED_EVENT subscription in `mountParameters()` will
+    // re-enable it after a commit. `viewport.setMaster` already called
+    // `layFlat.notifyMasterReset()`, which fires committed=false, so any
+    // stale enabled state from a previous master is cleared.
+    if (generateButton) {
+      generateButton.setHasMaster(true);
     }
   } catch (err) {
     console.error('[open-stl] unexpected error during load:', err);

--- a/src/renderer/scene/layFlatController.ts
+++ b/src/renderer/scene/layFlatController.ts
@@ -74,6 +74,26 @@ export const LAY_FLAT_WIDGETS_TAG = 'lay-flat-widgets';
  */
 export const LAY_FLAT_ACTIVE_EVENT = 'lay-flat-active-changed';
 
+/**
+ * Custom event fired on `document` when the "orientation committed" state
+ * changes. Distinct from `LAY_FLAT_ACTIVE_EVENT` (which tracks picking-mode
+ * in/out) — this tracks whether the user has actually committed a face via
+ * `commit()`:
+ *
+ *   - `{ detail: true }`  after a successful `commit()` (face rotated onto
+ *                         the bed; controller auto-exits picking).
+ *   - `{ detail: false }` when the orientation is returned to the pristine
+ *                         state via `reset()`.
+ *   - `{ detail: false }` when `notifyMasterReset()` is called (a new STL
+ *                         is loaded → orientation resets to identity; any
+ *                         previous commit must NOT carry over).
+ *
+ * The Generate-mold button subscribes to this event to gate itself behind
+ * a committed orientation (issue #36). Consumers should prefer this event
+ * over polling `MountedViewport.isOrientationCommitted()` on every frame.
+ */
+export const LAY_FLAT_COMMITTED_EVENT = 'lay-flat-committed';
+
 /** Dimensions for the flat normal-indicator quad, in mm. */
 const NORMAL_QUAD_SIZE_MM = 15;
 
@@ -86,6 +106,19 @@ export interface LayFlatController {
   reset(): void;
   /** Whether picking mode is currently active. */
   isActive(): boolean;
+  /**
+   * Whether the user has committed an orientation since the last reset or
+   * master load. Mirrored onto `document` via `LAY_FLAT_COMMITTED_EVENT`.
+   */
+  isCommitted(): boolean;
+  /**
+   * Signal that the master mesh has been replaced (new STL loaded). The
+   * controller forgets any previous committed orientation and fires
+   * `LAY_FLAT_COMMITTED_EVENT` with `detail: false` so gated UI re-locks.
+   * The scene-graph side of the master swap is owned by `setMaster`; this
+   * method only manages the controller's own state + event.
+   */
+  notifyMasterReset(): void;
   /** Tear down permanently — remove widget group from the scene. */
   dispose(): void;
 }
@@ -116,6 +149,10 @@ export function createLayFlatController(
 
   let active = false;
   let disposed = false;
+  // Orientation-committed flag (issue #36). Starts false: a freshly-loaded
+  // master has pristine identity orientation. Flipped true inside `commit()`,
+  // flipped false inside `reset()` and `notifyMasterReset()`.
+  let committed = false;
 
   // --- Widgets --------------------------------------------------------------
 
@@ -336,8 +373,21 @@ export function createLayFlatController(
     group.quaternion.normalize();
 
     // Clean up hover widgets + auto-exit picking mode (issue AC: "picking
-    // mode auto-exits on commit").
+    // mode auto-exits on commit"). `disable()` fires its own active-event;
+    // sequencing it BEFORE the committed-event means subscribers observing
+    // both events see them in causal order: "picking ended → orientation
+    // committed". This matters for the Generate-mold button gate (#36):
+    // the button's enable tick lands after the picking cue has cleared,
+    // not in the middle of it.
     disable();
+
+    // Flip committed=true and notify — AFTER the rotation has been applied
+    // and the scene-graph is consistent. The Generate-mold button (#36)
+    // listens to this event to unlock itself.
+    if (!committed) {
+      committed = true;
+      emitCommittedChanged();
+    }
   }
 
   function reset(): void {
@@ -355,6 +405,28 @@ export function createLayFlatController(
     // Reset does not force picking mode on or off — the user might want to
     // reset while the toggle is active (to pick a different face cleanly)
     // or while it is inactive (pure "undo"). Respect current state.
+
+    // Orientation has been returned to identity → the committed flag must
+    // drop, re-disabling the Generate-mold button (#36). Only fire the
+    // event when the flag actually transitions, to keep the event stream
+    // meaningful.
+    if (committed) {
+      committed = false;
+      emitCommittedChanged();
+    }
+  }
+
+  /**
+   * External signal: the master mesh has been replaced (new STL loaded).
+   * Any previous committed orientation is no longer meaningful — the new
+   * master enters at identity with the committed flag cleared. See
+   * issue #36 AC: "After Open STL loads a new master → button re-disabled
+   * (inherited commit state does not carry over)".
+   */
+  function notifyMasterReset(): void {
+    if (!committed) return;
+    committed = false;
+    emitCommittedChanged();
   }
 
   // --- Enable / disable / dispose -------------------------------------------
@@ -362,6 +434,19 @@ export function createLayFlatController(
   function emitActiveChanged(): void {
     document.dispatchEvent(
       new CustomEvent<boolean>(LAY_FLAT_ACTIVE_EVENT, { detail: active }),
+    );
+  }
+
+  /**
+   * Fire `LAY_FLAT_COMMITTED_EVENT` with the current `committed` flag. The
+   * Generate-mold button subscribes so its disabled state mirrors the
+   * controller's truth. We always fire on transitions (caller's
+   * responsibility to only call when the flag actually changed) so
+   * listeners receive a consistent sequence.
+   */
+  function emitCommittedChanged(): void {
+    document.dispatchEvent(
+      new CustomEvent<boolean>(LAY_FLAT_COMMITTED_EVENT, { detail: committed }),
     );
   }
 
@@ -406,6 +491,8 @@ export function createLayFlatController(
     disable,
     reset,
     isActive: () => active,
+    isCommitted: () => committed,
+    notifyMasterReset,
     dispose,
   };
 }

--- a/src/renderer/scene/viewport.ts
+++ b/src/renderer/scene/viewport.ts
@@ -71,6 +71,16 @@ export interface MountedViewport {
    * master is loaded.
    */
   resetOrientation: () => void;
+  /**
+   * Whether the user has committed an orientation via Place-on-face since
+   * the last reset or master load. Mirrors the controller's `isCommitted()`.
+   *
+   * The Generate-mold button (issue #36) gates on this: pristine /
+   * post-reset / post-Open-STL state returns `false`; post-commit returns
+   * `true`. Subscribers should prefer `LAY_FLAT_COMMITTED_EVENT` on
+   * `document` over polling this on every frame.
+   */
+  isOrientationCommitted: () => boolean;
   /** Stop RAF, detach listeners, dispose GPU resources, remove the canvas. */
   dispose: () => void;
 }
@@ -188,6 +198,12 @@ export function mount(container: HTMLElement): MountedViewport {
     if (layFlat.isActive()) layFlat.disable();
     const result = await sceneSetMaster(scene, buffer);
     layFlatMasterMesh = result.mesh;
+    // `scene/master.ts` resets the group quaternion to identity on every
+    // load (see its "Reset rotation before adding the new mesh" block).
+    // Tell the lay-flat controller so it clears any lingering committed
+    // flag and fires `LAY_FLAT_COMMITTED_EVENT` — the Generate-mold button
+    // (#36) re-disables itself on this edge.
+    layFlat.notifyMasterReset();
     frameToBox3(camera, controls, result.bbox);
     // Signal test hooks, then install a fresh promise so a second load
     // is independently awaitable.
@@ -258,6 +274,7 @@ export function mount(container: HTMLElement): MountedViewport {
     disableFacePicking: () => layFlat.disable(),
     isFacePickingActive: () => layFlat.isActive(),
     resetOrientation: () => layFlat.reset(),
+    isOrientationCommitted: () => layFlat.isCommitted(),
     dispose,
   };
 

--- a/src/renderer/ui/generateButton.ts
+++ b/src/renderer/ui/generateButton.ts
@@ -1,0 +1,180 @@
+// src/renderer/ui/generateButton.ts
+//
+// The "Generate mold" button + hint block that sits at the TOP of the right
+// sidebar, above the parameter form. Part of the UX gate from issue #36:
+// mold generation is explicit (button-driven), not automatic, and must be
+// locked until the user commits an orientation via Place-on-face.
+//
+// Shape:
+//
+//   <div class="generate-block">
+//     <button class="generate-block__button" />
+//     <p class="generate-block__hint" />
+//   </div>
+//
+// State machine (driven externally by `setEnabled`):
+//
+//   disabled + no master       → button disabled, hint = "Load an STL to begin."
+//   disabled + master loaded   → button disabled, hint = "Orient the part on its base..."
+//   enabled  + master loaded   → button enabled (accent), hint = "Ready to generate"
+//
+// The caller (`main.ts`) decides which of the three states applies by
+// calling `setEnabled(true/false)` and `setHasMaster(true/false)` — those
+// are two orthogonal axes. We keep state internal so the component can
+// re-render consistently on every change.
+//
+// This module is renderer-thin and framework-free: plain DOM, i18n keys,
+// accent colour via the `--accent` CSS token (no new colour tokens).
+
+import { t } from '../i18n';
+
+/** Opaque handle returned by `mountGenerateButton`. */
+export interface GenerateButtonApi {
+  /** The outer `<div>` — caller inserts it wherever they need. */
+  readonly element: HTMLElement;
+  /**
+   * Flip the enabled state. When enabled, the button is clickable and the
+   * hint shows "Ready to generate"; when disabled and a master is loaded,
+   * the hint shows the orient-first instruction.
+   *
+   * Idempotent: calling with the same value twice is a no-op.
+   */
+  setEnabled(enabled: boolean): void;
+  /**
+   * Report whether an STL is currently loaded. Affects the hint text only
+   * when the button is in the disabled state (see the state machine above).
+   */
+  setHasMaster(hasMaster: boolean): void;
+  /** Read the current enabled flag (useful for tests). */
+  isEnabled(): boolean;
+  /** Detach from the DOM + release listeners. */
+  destroy(): void;
+}
+
+export interface GenerateButtonOptions {
+  /**
+   * Fires when the user clicks the button in the enabled state. The caller
+   * is responsible for the actual generation work (console.log stub per
+   * issue #36 scope; Phase 3c wave-1-geometry replaces with the real call).
+   *
+   * Clicks on a disabled button are swallowed here — no need for the
+   * handler to re-check. `aria-disabled` + native `disabled` are also set.
+   */
+  onGenerate: () => void;
+}
+
+/**
+ * Mount the Generate-mold block into `container` (typically the
+ * `<aside id="sidebar">`). The caller is responsible for placing the
+ * returned `element` above the parameter form — we return the node
+ * rather than auto-appending so `main.ts` controls DOM order.
+ *
+ * Initial state: disabled, no master — hint reads "Load an STL to begin."
+ */
+export function mountGenerateButton(
+  container: HTMLElement,
+  options: GenerateButtonOptions,
+): GenerateButtonApi {
+  const { onGenerate } = options;
+
+  const root = document.createElement('div');
+  root.className = 'generate-block';
+  root.dataset['testid'] = 'generate-block';
+
+  // --- Button -----------------------------------------------------------------
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'generate-block__button';
+  button.dataset['testid'] = 'generate-btn';
+  button.textContent = t('generate.button');
+  // Start disabled: no master loaded → user has to Open STL + commit a
+  // face first. Both the native `disabled` attribute and `aria-disabled`
+  // are set so assistive-tech users get the same cue as sighted ones.
+  button.disabled = true;
+  button.setAttribute('aria-disabled', 'true');
+
+  // --- Hint -----------------------------------------------------------------
+  const hint = document.createElement('p');
+  hint.className = 'generate-block__hint';
+  hint.dataset['testid'] = 'generate-hint';
+  // Hint content is re-rendered by `renderHint()` below so the initial
+  // assignment is just the default starting state.
+
+  root.appendChild(button);
+  root.appendChild(hint);
+
+  // --- State + render -------------------------------------------------------
+  let enabled = false;
+  let hasMaster = false;
+
+  function renderButton(): void {
+    button.disabled = !enabled;
+    button.setAttribute('aria-disabled', enabled ? 'false' : 'true');
+    // We don't toggle any extra class — CSS handles the accent-vs-muted
+    // swap purely off the `:disabled` pseudo-class.
+  }
+
+  function renderHint(): void {
+    // Three-state selector per the spec:
+    //   enabled              → "Ready to generate" (accent colour)
+    //   disabled + master    → "Orient the part on its base..."
+    //   disabled + no master → "Load an STL to begin."
+    if (enabled) {
+      hint.textContent = t('generate.ready');
+      hint.classList.add('generate-block__hint--ready');
+    } else {
+      hint.classList.remove('generate-block__hint--ready');
+      hint.textContent = hasMaster ? t('generate.hint') : t('generate.noMaster');
+    }
+  }
+
+  function render(): void {
+    renderButton();
+    renderHint();
+  }
+
+  // --- Click wiring ---------------------------------------------------------
+  // Native `disabled` buttons don't fire click events in Chromium, so the
+  // `if (!enabled)` guard is belt-and-braces — it also covers the
+  // synthetic-click path some tests use to dispatch through `dispatchEvent`
+  // (which bypasses the native disabled check).
+  const onClick = (): void => {
+    if (!enabled) return;
+    try {
+      onGenerate();
+    } catch (err) {
+      // Swallow + log. The onGenerate stub logs a message today; any future
+      // real generator will have its own error-handling UI, so we just make
+      // sure a thrown error here doesn't break the click loop. No unhandled
+      // promise rejection either — `onGenerate` is void, not Promise.
+      console.error('[generate] onGenerate threw:', err);
+    }
+  };
+  button.addEventListener('click', onClick);
+
+  // Initial render.
+  render();
+
+  container.appendChild(root);
+
+  return {
+    element: root,
+    setEnabled(next: boolean): void {
+      if (enabled === next) return;
+      enabled = next;
+      render();
+    },
+    setHasMaster(next: boolean): void {
+      if (hasMaster === next) return;
+      hasMaster = next;
+      render();
+    },
+    isEnabled(): boolean {
+      return enabled;
+    },
+    destroy(): void {
+      button.removeEventListener('click', onClick);
+      root.remove();
+    },
+  };
+}

--- a/tests/e2e/generate-gate.spec.ts
+++ b/tests/e2e/generate-gate.spec.ts
@@ -1,0 +1,346 @@
+// tests/e2e/generate-gate.spec.ts
+//
+// End-to-end for issue #36: the Generate-mold UX gate. Launches the real
+// Electron app, loads the mini-figurine fixture via the stubbed native Open
+// dialog, and asserts the four state transitions from the AC:
+//
+//   1. On app launch with no master loaded → button disabled, hint shows
+//      "Load an STL to begin.".
+//   2. After Open STL → button disabled, hint shows the "Orient the part..."
+//      instruction.
+//   3. After Place-on-face commits a face → button enabled, hint shows
+//      "Ready to generate".
+//   4. After Reset orientation → button disabled again, hint re-shows the
+//      "Orient the part..." instruction.
+//
+// Commit is driven through `window.__testHooks.viewport.enableFacePicking()`
+// plus a synthetic click at the canvas centre — the same technique the
+// lay-flat spec uses. The controller dispatches `LAY_FLAT_COMMITTED_EVENT`
+// and the renderer wiring in `main.ts` calls `generateButton.setEnabled()`.
+//
+// Clicking Generate when enabled must log the expected payload to the
+// console without unhandled rejections. We capture console messages via
+// `page.on('console')` and assert the expected string shows up.
+
+import { expect, test, type ConsoleMessage } from '@playwright/test';
+import { resolve } from 'node:path';
+import { launchApp } from './fixtures/app';
+
+const MINI_FIGURINE_PATH = resolve(
+  __dirname,
+  '..',
+  'fixtures',
+  'meshes',
+  'mini-figurine.stl',
+);
+
+test('generate-mold gate: disabled → enabled → disabled across commit/reset', async () => {
+  const app = await launchApp();
+  const consoleLogs: string[] = [];
+  try {
+    const page = await app.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
+
+    page.on('console', (msg: ConsoleMessage) => {
+      consoleLogs.push(msg.text());
+    });
+    page.on('pageerror', (err) => {
+      console.log(`[renderer:pageerror] ${err.message}`);
+    });
+
+    // AC 1: on launch, before any master, the button is disabled and the
+    // hint reads "Load an STL to begin.".
+    await expect(page.locator('[data-testid="generate-btn"]')).toBeDisabled();
+    const initialHint = await page
+      .locator('[data-testid="generate-hint"]')
+      .textContent();
+    expect(initialHint).toBe('Load an STL to begin.');
+
+    // Stub the native file dialog to return the fixture path — same pattern
+    // the lay-flat + smoke specs use.
+    await app.evaluate((_electron, fixturePath) => {
+      (
+        globalThis as unknown as {
+          __testDialogStub: {
+            showOpenDialog: () => Promise<{
+              canceled: boolean;
+              filePaths: string[];
+            }>;
+          };
+        }
+      ).__testDialogStub = {
+        showOpenDialog: () =>
+          Promise.resolve({ canceled: false, filePaths: [fixturePath] }),
+      };
+    }, MINI_FIGURINE_PATH);
+
+    const openBtn = page.locator('[data-testid="open-stl-btn"]');
+    await expect(openBtn).toBeVisible();
+    await expect(openBtn).toBeEnabled();
+
+    // Snapshot the masterLoaded promise BEFORE clicking Open STL.
+    await page.evaluate(() => {
+      const hooks = (
+        window as unknown as {
+          __testHooks?: { masterLoaded?: Promise<void> };
+        }
+      ).__testHooks;
+      if (!hooks?.masterLoaded) {
+        throw new Error('window.__testHooks.masterLoaded missing');
+      }
+      (
+        globalThis as unknown as { __pendingMasterLoaded: Promise<void> }
+      ).__pendingMasterLoaded = hooks.masterLoaded;
+    });
+
+    await openBtn.click();
+    await page.evaluate(
+      () =>
+        (
+          globalThis as unknown as { __pendingMasterLoaded: Promise<void> }
+        ).__pendingMasterLoaded,
+    );
+
+    // AC 2: after Open STL, button still disabled, hint flipped to the
+    // orient-first instruction.
+    await expect(page.locator('[data-testid="generate-btn"]')).toBeDisabled();
+    await expect(page.locator('[data-testid="generate-hint"]')).toHaveText(
+      'Orient the part on its base (use Place on face in the toolbar), then click Generate.',
+    );
+
+    // Commit a face via the viewport's test hook. Same camera positioning
+    // the lay-flat spec uses — point straight down at the mini-figurine so
+    // a canvas-centre click hits its top face.
+    await page.evaluate(() => {
+      type ViewportHooks = {
+        viewport?: {
+          camera: {
+            position: { set: (x: number, y: number, z: number) => void };
+            up: { set: (x: number, y: number, z: number) => void };
+            lookAt: (x: number, y: number, z: number) => void;
+            updateMatrixWorld: () => void;
+            updateProjectionMatrix: () => void;
+          };
+          enableFacePicking: () => void;
+        };
+      };
+      const hooks = (window as unknown as { __testHooks?: ViewportHooks })
+        .__testHooks;
+      const vp = hooks?.viewport;
+      if (!vp) throw new Error('viewport hook missing');
+      vp.camera.position.set(0, 250, 0);
+      vp.camera.up.set(0, 0, -1);
+      vp.camera.lookAt(0, 35, 0);
+      vp.camera.updateMatrixWorld();
+      vp.camera.updateProjectionMatrix();
+      vp.enableFacePicking();
+    });
+
+    // Synthesise a click at the canvas centre.
+    const canvasBox = await page.locator('#viewport canvas').boundingBox();
+    if (!canvasBox) throw new Error('canvas missing');
+    const cx = canvasBox.x + canvasBox.width / 2;
+    const cy = canvasBox.y + canvasBox.height / 2;
+    await page.mouse.move(cx, cy);
+    await page.mouse.click(cx, cy);
+
+    // Wait for the controller's auto-exit-on-commit so we know the commit
+    // event has fired. Then the button subscription updates via microtask.
+    await page.waitForFunction(
+      () => {
+        type ViewportHooks = {
+          viewport?: {
+            isFacePickingActive: () => boolean;
+            isOrientationCommitted: () => boolean;
+          };
+        };
+        const hooks = (window as unknown as { __testHooks?: ViewportHooks })
+          .__testHooks;
+        return (
+          hooks?.viewport?.isFacePickingActive() === false &&
+          hooks?.viewport?.isOrientationCommitted() === true
+        );
+      },
+      undefined,
+      { timeout: 5_000 },
+    );
+
+    // AC 3: after commit, button enabled, hint = "Ready to generate".
+    await expect(page.locator('[data-testid="generate-btn"]')).toBeEnabled();
+    await expect(page.locator('[data-testid="generate-hint"]')).toHaveText(
+      'Ready to generate',
+    );
+
+    // Clicking Generate must log the expected payload.
+    await page.locator('[data-testid="generate-btn"]').click();
+    // Give the microtask + console plumbing a moment to flush.
+    await page.waitForFunction(
+      () =>
+        Array.from(
+          (
+            globalThis as unknown as {
+              __capturedLogs?: string[];
+            }
+          ).__capturedLogs ?? [],
+        ).length > 0,
+      undefined,
+      // A short poll window; the fallback expects Playwright to have
+      // captured via its own `console` listener.
+      { timeout: 1_000 },
+    ).catch(() => {
+      // Playwright's `page.on('console')` is the authoritative channel;
+      // the waitForFunction above is advisory only.
+    });
+    // Assert via the Playwright-captured log stream.
+    const didLog = consoleLogs.some((l) => l.includes('[generate] requested'));
+    expect(didLog).toBe(true);
+
+    // AC 4: Reset orientation flips the gate back off.
+    await page.evaluate(() => {
+      type ViewportHooks = {
+        viewport?: { resetOrientation: () => void };
+      };
+      const hooks = (window as unknown as { __testHooks?: ViewportHooks })
+        .__testHooks;
+      hooks?.viewport?.resetOrientation();
+    });
+    await expect(page.locator('[data-testid="generate-btn"]')).toBeDisabled();
+    await expect(page.locator('[data-testid="generate-hint"]')).toHaveText(
+      'Orient the part on its base (use Place on face in the toolbar), then click Generate.',
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test('generate-mold gate: loading a second master re-locks the button', async () => {
+  // AC: "After Open STL loads a new master: button re-disabled (inherited
+  // commit state does not carry over)". Exercises the `notifyMasterReset`
+  // wiring in `viewport.setMaster` → controller → button.
+  const app = await launchApp();
+  try {
+    const page = await app.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
+
+    // Stub the dialog to return the mini-figurine both times.
+    await app.evaluate((_electron, fixturePath) => {
+      (
+        globalThis as unknown as {
+          __testDialogStub: {
+            showOpenDialog: () => Promise<{
+              canceled: boolean;
+              filePaths: string[];
+            }>;
+          };
+        }
+      ).__testDialogStub = {
+        showOpenDialog: () =>
+          Promise.resolve({ canceled: false, filePaths: [fixturePath] }),
+      };
+    }, MINI_FIGURINE_PATH);
+
+    const openBtn = page.locator('[data-testid="open-stl-btn"]');
+    await expect(openBtn).toBeVisible();
+
+    // First load + commit.
+    await page.evaluate(() => {
+      const hooks = (
+        window as unknown as {
+          __testHooks?: { masterLoaded?: Promise<void> };
+        }
+      ).__testHooks;
+      if (!hooks?.masterLoaded) {
+        throw new Error('masterLoaded hook missing');
+      }
+      (
+        globalThis as unknown as { __pendingMasterLoaded: Promise<void> }
+      ).__pendingMasterLoaded = hooks.masterLoaded;
+    });
+    await openBtn.click();
+    await page.evaluate(
+      () =>
+        (
+          globalThis as unknown as { __pendingMasterLoaded: Promise<void> }
+        ).__pendingMasterLoaded,
+    );
+
+    // Commit a face — reuse the camera-down-click technique.
+    await page.evaluate(() => {
+      type ViewportHooks = {
+        viewport?: {
+          camera: {
+            position: { set: (x: number, y: number, z: number) => void };
+            up: { set: (x: number, y: number, z: number) => void };
+            lookAt: (x: number, y: number, z: number) => void;
+            updateMatrixWorld: () => void;
+            updateProjectionMatrix: () => void;
+          };
+          enableFacePicking: () => void;
+        };
+      };
+      const hooks = (window as unknown as { __testHooks?: ViewportHooks })
+        .__testHooks;
+      const vp = hooks?.viewport;
+      if (!vp) throw new Error('viewport hook missing');
+      vp.camera.position.set(0, 250, 0);
+      vp.camera.up.set(0, 0, -1);
+      vp.camera.lookAt(0, 35, 0);
+      vp.camera.updateMatrixWorld();
+      vp.camera.updateProjectionMatrix();
+      vp.enableFacePicking();
+    });
+    const canvasBox = await page.locator('#viewport canvas').boundingBox();
+    if (!canvasBox) throw new Error('canvas missing');
+    await page.mouse.move(
+      canvasBox.x + canvasBox.width / 2,
+      canvasBox.y + canvasBox.height / 2,
+    );
+    await page.mouse.click(
+      canvasBox.x + canvasBox.width / 2,
+      canvasBox.y + canvasBox.height / 2,
+    );
+    await page.waitForFunction(
+      () => {
+        type ViewportHooks = {
+          viewport?: { isOrientationCommitted: () => boolean };
+        };
+        const hooks = (window as unknown as { __testHooks?: ViewportHooks })
+          .__testHooks;
+        return hooks?.viewport?.isOrientationCommitted() === true;
+      },
+      undefined,
+      { timeout: 5_000 },
+    );
+    await expect(page.locator('[data-testid="generate-btn"]')).toBeEnabled();
+
+    // Second load — refresh the masterLoaded promise first.
+    await page.evaluate(() => {
+      const hooks = (
+        window as unknown as {
+          __testHooks?: { masterLoaded?: Promise<void> };
+        }
+      ).__testHooks;
+      if (!hooks?.masterLoaded) {
+        throw new Error('masterLoaded hook missing');
+      }
+      (
+        globalThis as unknown as { __pendingMasterLoaded: Promise<void> }
+      ).__pendingMasterLoaded = hooks.masterLoaded;
+    });
+    await openBtn.click();
+    await page.evaluate(
+      () =>
+        (
+          globalThis as unknown as { __pendingMasterLoaded: Promise<void> }
+        ).__pendingMasterLoaded,
+    );
+
+    // Button must be re-disabled after the new load.
+    await expect(page.locator('[data-testid="generate-btn"]')).toBeDisabled();
+    await expect(page.locator('[data-testid="generate-hint"]')).toHaveText(
+      'Orient the part on its base (use Place on face in the toolbar), then click Generate.',
+    );
+  } finally {
+    await app.close();
+  }
+});

--- a/tests/renderer/scene/layFlat-committed.test.ts
+++ b/tests/renderer/scene/layFlat-committed.test.ts
@@ -1,0 +1,300 @@
+// tests/renderer/scene/layFlat-committed.test.ts
+//
+// @vitest-environment happy-dom
+//
+// Pins the `LAY_FLAT_COMMITTED_EVENT` contract (issue #36). This event is
+// the signal the Generate-mold button (`src/renderer/ui/generateButton.ts`)
+// subscribes to for its enable/disable state. The contract:
+//
+//   - Fires with `{ detail: true }` after a successful `commit(pick, mesh)`.
+//   - Fires with `{ detail: false }` after `reset()` IF it was previously true.
+//   - Fires with `{ detail: false }` after `notifyMasterReset()` IF it was true.
+//   - Does NOT fire on transitions that don't change the flag (e.g. calling
+//     `reset()` on a non-committed controller, or `notifyMasterReset()` on
+//     a pristine one).
+//
+// The commit path is the tricky one: `layFlatController.commit` is not
+// exported, so we drive the full pipeline — `enable()` → synthetic click
+// over a face in the canvas — just like the E2E spec does, but in a
+// happy-dom + real Three.js + real three-mesh-bvh stack. No WebGL context
+// is required because the controller's raycast path goes through the
+// BVH, which is CPU-only.
+//
+// happy-dom caveat: `HTMLCanvasElement.getBoundingClientRect()` in happy-dom
+// returns a zero-size rect by default, which `pickFaceUnderPointer` correctly
+// rejects. We monkey-patch `getBoundingClientRect` on the canvas instance so
+// the test has a meaningful viewport.
+
+import {
+  BoxGeometry,
+  Mesh,
+  MeshBasicMaterial,
+  Group,
+  PerspectiveCamera,
+  Scene,
+  Vector3,
+} from 'three';
+import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  createLayFlatController,
+  LAY_FLAT_COMMITTED_EVENT,
+  type LayFlatController,
+} from '@/renderer/scene/layFlatController';
+import { prepareMeshForPicking } from '@/renderer/scene/picking';
+
+/**
+ * Build the minimal scene + controller harness. We can't use the real
+ * `createScene()` because it constructs WebGL-specific gizmos whose
+ * materials reference patterns happy-dom can't evaluate; but the
+ * controller itself only needs a `Scene` with a `widgets` Group to
+ * attach hover overlays to, plus camera/controls/canvas/getMasterMesh.
+ */
+function buildHarness(): {
+  scene: Scene;
+  camera: PerspectiveCamera;
+  controls: OrbitControls;
+  canvas: HTMLCanvasElement;
+  group: Group;
+  mesh: Mesh;
+  controller: LayFlatController;
+  dispose: () => void;
+} {
+  const scene = new Scene();
+
+  // Widgets group — `createLayFlatController` looks for a child with
+  // `userData.tag === 'widgets'`. Without it the controller silently
+  // attaches widgets to the scene root; the behaviour under test doesn't
+  // care, but we include it for parity with production scene-build order.
+  const widgets = new Group();
+  widgets.userData['tag'] = 'widgets';
+  scene.add(widgets);
+
+  // Master group + mesh. A 2×2×2 box centered on origin, BVH-prepared for
+  // picking. Large enough that a ray from the top of the scene hits it
+  // reliably at any canvas-centre click.
+  const group = new Group();
+  group.userData['tag'] = 'master';
+  scene.add(group);
+  const geom = new BoxGeometry(2, 2, 2);
+  const mesh = new Mesh(geom, new MeshBasicMaterial());
+  group.add(mesh);
+  prepareMeshForPicking(mesh);
+
+  // Camera positioned directly above the box looking down. A click at the
+  // canvas centre is a ray straight down, hitting the top (+Y) face.
+  const camera = new PerspectiveCamera(50, 1, 0.1, 100);
+  camera.position.set(0, 10, 0);
+  camera.up.set(0, 0, -1);
+  camera.lookAt(0, 0, 0);
+  camera.updateMatrixWorld();
+  camera.updateProjectionMatrix();
+
+  // Minimal controls stub — the controller's commit/reset path calls
+  // `frameToBox3(camera, controls, box)`, which expects `controls.target`
+  // to be a Three `Vector3` (so it can `.copy(center)`) plus an `update()`.
+  // A real `OrbitControls` is overkill; we give it a real Vector3 target
+  // and a no-op update. Nothing in this test asserts on the camera state.
+  const controls = {
+    target: new Vector3(),
+    update() {},
+  } as unknown as OrbitControls;
+
+  // Canvas — happy-dom provides HTMLCanvasElement but `getBoundingClientRect`
+  // returns zeros. Override to give the viewport a 200×200 footprint so
+  // `pickFaceUnderPointer` has non-degenerate NDC math.
+  const canvas = document.createElement('canvas');
+  canvas.width = 200;
+  canvas.height = 200;
+  document.body.appendChild(canvas);
+  Object.defineProperty(canvas, 'getBoundingClientRect', {
+    value: () => ({
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 200,
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 0,
+      toJSON() {
+        return {};
+      },
+    }),
+  });
+
+  const controller = createLayFlatController({
+    scene,
+    camera,
+    controls,
+    canvas,
+    getMasterMesh: () => mesh,
+  });
+
+  return {
+    scene,
+    camera,
+    controls,
+    canvas,
+    group,
+    mesh,
+    controller,
+    dispose: () => {
+      controller.dispose();
+      canvas.remove();
+    },
+  };
+}
+
+/**
+ * Capture every `LAY_FLAT_COMMITTED_EVENT` dispatched on `document`
+ * during the callback. Returns an array of the `detail` booleans.
+ */
+function captureCommittedDetails(
+  run: () => void,
+): boolean[] {
+  const details: boolean[] = [];
+  const handler = (ev: Event): void => {
+    details.push((ev as CustomEvent<boolean>).detail);
+  };
+  document.addEventListener(LAY_FLAT_COMMITTED_EVENT, handler);
+  try {
+    run();
+  } finally {
+    document.removeEventListener(LAY_FLAT_COMMITTED_EVENT, handler);
+  }
+  return details;
+}
+
+let harness: ReturnType<typeof buildHarness> | null = null;
+
+beforeEach(() => {
+  harness = buildHarness();
+});
+afterEach(() => {
+  harness?.dispose();
+  harness = null;
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('LAY_FLAT_COMMITTED_EVENT — initial + idempotent state', () => {
+  test('isCommitted() returns false on a fresh controller (before any commit)', () => {
+    const { controller } = harness!;
+    expect(controller.isCommitted()).toBe(false);
+  });
+
+  test('reset() on a non-committed controller does NOT fire the event', () => {
+    const { controller } = harness!;
+    const details = captureCommittedDetails(() => {
+      controller.reset();
+    });
+    expect(details).toEqual([]);
+    expect(controller.isCommitted()).toBe(false);
+  });
+
+  test('notifyMasterReset() on a pristine controller does NOT fire the event', () => {
+    const { controller } = harness!;
+    const details = captureCommittedDetails(() => {
+      controller.notifyMasterReset();
+    });
+    expect(details).toEqual([]);
+    expect(controller.isCommitted()).toBe(false);
+  });
+});
+
+describe('LAY_FLAT_COMMITTED_EVENT — commit path', () => {
+  /**
+   * Drive a commit through the public API: enable picking mode, dispatch a
+   * click at the canvas centre. The camera is positioned straight above the
+   * box (set up in `buildHarness`) so a centred ray hits the +Y face, which
+   * the controller's commit logic picks + rotates onto the bed.
+   */
+  function drivePickAndCommit(): void {
+    const { controller, canvas } = harness!;
+    controller.enable();
+    const click = new Event('click', { bubbles: true });
+    // PointerEvent constructor isn't fully implemented in happy-dom; the
+    // controller only reads `.clientX`/`.clientY`/`.button`, so assign
+    // them directly onto the Event.
+    Object.assign(click, { clientX: 100, clientY: 100, button: 0 });
+    canvas.dispatchEvent(click);
+  }
+
+  test('commit fires the event with detail=true', () => {
+    const { controller } = harness!;
+    const details = captureCommittedDetails(() => {
+      drivePickAndCommit();
+    });
+    expect(details).toContain(true);
+    expect(details[details.length - 1]).toBe(true);
+    expect(controller.isCommitted()).toBe(true);
+  });
+
+  test('a second commit does NOT re-fire the event (committed is idempotent)', () => {
+    const { controller } = harness!;
+    drivePickAndCommit();
+    expect(controller.isCommitted()).toBe(true);
+
+    const details = captureCommittedDetails(() => {
+      drivePickAndCommit();
+    });
+    // `commit()` only emits when the flag TRANSITIONS false→true. A second
+    // commit (already true) is silent on this event.
+    expect(details).toEqual([]);
+    expect(controller.isCommitted()).toBe(true);
+  });
+});
+
+describe('LAY_FLAT_COMMITTED_EVENT — reset path', () => {
+  test('reset() after a commit fires the event with detail=false', () => {
+    const { controller } = harness!;
+    // Drive the initial commit first (outside the capture so it doesn't
+    // pollute the assertion).
+    controller.enable();
+    const click = new Event('click');
+    Object.assign(click, { clientX: 100, clientY: 100, button: 0 });
+    harness!.canvas.dispatchEvent(click);
+    expect(controller.isCommitted()).toBe(true);
+
+    const details = captureCommittedDetails(() => {
+      controller.reset();
+    });
+    expect(details).toEqual([false]);
+    expect(controller.isCommitted()).toBe(false);
+  });
+});
+
+describe('LAY_FLAT_COMMITTED_EVENT — notifyMasterReset path', () => {
+  test('notifyMasterReset after a commit fires the event with detail=false', () => {
+    const { controller } = harness!;
+    controller.enable();
+    const click = new Event('click');
+    Object.assign(click, { clientX: 100, clientY: 100, button: 0 });
+    harness!.canvas.dispatchEvent(click);
+    expect(controller.isCommitted()).toBe(true);
+
+    const details = captureCommittedDetails(() => {
+      controller.notifyMasterReset();
+    });
+    expect(details).toEqual([false]);
+    expect(controller.isCommitted()).toBe(false);
+  });
+
+  test('notifyMasterReset after another notifyMasterReset is silent (already false)', () => {
+    const { controller } = harness!;
+    // Commit → clear → clear again.
+    controller.enable();
+    const click = new Event('click');
+    Object.assign(click, { clientX: 100, clientY: 100, button: 0 });
+    harness!.canvas.dispatchEvent(click);
+    controller.notifyMasterReset();
+    expect(controller.isCommitted()).toBe(false);
+
+    const details = captureCommittedDetails(() => {
+      controller.notifyMasterReset();
+    });
+    expect(details).toEqual([]);
+  });
+});

--- a/tests/renderer/ui/generateButton.test.ts
+++ b/tests/renderer/ui/generateButton.test.ts
@@ -1,0 +1,294 @@
+// tests/renderer/ui/generateButton.test.ts
+//
+// @vitest-environment happy-dom
+//
+// DOM-level tests for the "Generate mold" block (issue #36). Covers the
+// state machine in `mountGenerateButton`:
+//
+//   1. Mounts a button + hint paragraph inside the container.
+//   2. Initial state: button disabled, hint reads "Load an STL to begin."
+//   3. `setHasMaster(true)` with still-disabled button → hint reads the
+//      orient-first instruction.
+//   4. `setEnabled(true)` → button clickable, hint reads "Ready to generate",
+//      hint carries the accent class.
+//   5. `setEnabled(false)` restores the disabled-with-master hint.
+//   6. Click when enabled fires `onGenerate`; click when disabled is a no-op.
+//   7. `aria-disabled` mirrors the native `disabled` attribute for a11y.
+//   8. All visible strings resolve through i18n (no hardcoded English in the
+//      component).
+
+import i18next from 'i18next';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { initI18n } from '@/renderer/i18n';
+import { mountGenerateButton } from '@/renderer/ui/generateButton';
+
+function mount(onGenerate: () => void = () => {}): {
+  container: HTMLElement;
+  api: ReturnType<typeof mountGenerateButton>;
+} {
+  const container = document.createElement('aside');
+  container.id = 'sidebar';
+  document.body.appendChild(container);
+  const api = mountGenerateButton(container, { onGenerate });
+  return { container, api };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  initI18n();
+});
+
+describe('generateButton — rendering', () => {
+  test('mounts a button + hint inside the container', () => {
+    const { container } = mount();
+    expect(
+      container.querySelector('[data-testid="generate-block"]'),
+    ).toBeTruthy();
+    expect(container.querySelector('[data-testid="generate-btn"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="generate-hint"]')).toBeTruthy();
+  });
+
+  test('initial state: button disabled + hint reads "Load an STL to begin."', () => {
+    const { container } = mount();
+    const btn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="generate-btn"]',
+    )!;
+    const hint = container.querySelector<HTMLElement>(
+      '[data-testid="generate-hint"]',
+    )!;
+
+    expect(btn.disabled).toBe(true);
+    expect(btn.getAttribute('aria-disabled')).toBe('true');
+    expect(btn.textContent).toBe(i18next.t('generate.button'));
+    expect(hint.textContent).toBe(i18next.t('generate.noMaster'));
+    // No accent class in disabled state.
+    expect(hint.classList.contains('generate-block__hint--ready')).toBe(false);
+  });
+
+  test('button is tab-focusable by default (no explicit tabindex opt-out)', () => {
+    const { container } = mount();
+    const btn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="generate-btn"]',
+    )!;
+    // Native <button> is in the tab order unless disabled. `tabIndex` on a
+    // default button is 0. We don't assert `!btn.disabled` here because the
+    // initial state IS disabled; instead we check the element has a sane
+    // tabIndex after we explicitly flip `setEnabled(true)`.
+    expect(btn.tabIndex).toBe(0);
+  });
+});
+
+describe('generateButton — state transitions', () => {
+  test('setHasMaster(true) while disabled → hint switches to "Orient the part..."', () => {
+    const { container, api } = mount();
+    api.setHasMaster(true);
+    const hint = container.querySelector<HTMLElement>(
+      '[data-testid="generate-hint"]',
+    )!;
+    expect(hint.textContent).toBe(i18next.t('generate.hint'));
+    // Still no accent — only enabled state gets the ready tint.
+    expect(hint.classList.contains('generate-block__hint--ready')).toBe(false);
+  });
+
+  test('setEnabled(true) → button clickable + aria-disabled=false + hint = "Ready to generate"', () => {
+    const { container, api } = mount();
+    api.setHasMaster(true);
+    api.setEnabled(true);
+
+    const btn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="generate-btn"]',
+    )!;
+    const hint = container.querySelector<HTMLElement>(
+      '[data-testid="generate-hint"]',
+    )!;
+
+    expect(btn.disabled).toBe(false);
+    expect(btn.getAttribute('aria-disabled')).toBe('false');
+    expect(hint.textContent).toBe(i18next.t('generate.ready'));
+    expect(hint.classList.contains('generate-block__hint--ready')).toBe(true);
+  });
+
+  test('setEnabled(false) after enable → hint reverts (based on hasMaster)', () => {
+    const { container, api } = mount();
+    api.setHasMaster(true);
+    api.setEnabled(true);
+    api.setEnabled(false);
+
+    const btn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="generate-btn"]',
+    )!;
+    const hint = container.querySelector<HTMLElement>(
+      '[data-testid="generate-hint"]',
+    )!;
+
+    expect(btn.disabled).toBe(true);
+    expect(btn.getAttribute('aria-disabled')).toBe('true');
+    expect(hint.textContent).toBe(i18next.t('generate.hint'));
+    expect(hint.classList.contains('generate-block__hint--ready')).toBe(false);
+  });
+
+  test('setEnabled(false) with no master → hint reverts to "Load an STL to begin."', () => {
+    // Simulates Reset orientation (committed → uncommitted) happening WITHOUT
+    // a new master load. In practice hasMaster stays true after commit, but
+    // this test covers the orthogonality of the two flags defensively.
+    const { container, api } = mount();
+    api.setHasMaster(false);
+    api.setEnabled(true); // hypothetical — the caller shouldn't do this but
+    // the component still renders the right hint.
+    api.setEnabled(false);
+
+    const hint = container.querySelector<HTMLElement>(
+      '[data-testid="generate-hint"]',
+    )!;
+    expect(hint.textContent).toBe(i18next.t('generate.noMaster'));
+  });
+
+  test('isEnabled() reflects the last setEnabled call', () => {
+    const { api } = mount();
+    expect(api.isEnabled()).toBe(false);
+    api.setEnabled(true);
+    expect(api.isEnabled()).toBe(true);
+    api.setEnabled(false);
+    expect(api.isEnabled()).toBe(false);
+  });
+
+  test('idempotent setEnabled / setHasMaster (same value twice is a no-op)', () => {
+    // Spy on the underlying render by checking that click still fires
+    // correctly after redundant state flips — if the component re-wired
+    // the listener on every call, a stale listener could fire twice.
+    const onGenerate = vi.fn();
+    const { container, api } = mount(onGenerate);
+    api.setHasMaster(true);
+    api.setHasMaster(true);
+    api.setEnabled(true);
+    api.setEnabled(true);
+    const btn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="generate-btn"]',
+    )!;
+    btn.click();
+    expect(onGenerate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('generateButton — click wiring', () => {
+  test('click when enabled fires onGenerate', () => {
+    const onGenerate = vi.fn();
+    const { container, api } = mount(onGenerate);
+    api.setHasMaster(true);
+    api.setEnabled(true);
+
+    const btn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="generate-btn"]',
+    )!;
+    btn.click();
+
+    expect(onGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  test('click when disabled is a no-op (native + synthetic paths)', () => {
+    const onGenerate = vi.fn();
+    const { container } = mount(onGenerate);
+    const btn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="generate-btn"]',
+    )!;
+
+    // Native path — `.click()` on a disabled button doesn't fire in Chromium
+    // and happy-dom matches that behaviour.
+    btn.click();
+
+    // Synthetic dispatch bypasses the native disabled check; the component's
+    // own guard inside the click handler must still swallow the invocation.
+    btn.dispatchEvent(new Event('click', { bubbles: true }));
+
+    expect(onGenerate).not.toHaveBeenCalled();
+  });
+
+  test('keyboard activation: Enter/Space fire via native button semantics', () => {
+    // Native <button> turns Enter + Space into a synthesised click. We
+    // assert the listener wired here is the SAME listener the click path
+    // hits, not some keydown duplicate. Dispatching a `click` event is
+    // sufficient: every browser keyboard-activation path funnels through
+    // it (see e.g. MDN "Button: keyboard shortcuts"), and there's no
+    // kbd-specific branch in this component.
+    const onGenerate = vi.fn();
+    const { container, api } = mount(onGenerate);
+    api.setHasMaster(true);
+    api.setEnabled(true);
+    const btn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="generate-btn"]',
+    )!;
+
+    btn.dispatchEvent(new Event('click', { bubbles: true }));
+    expect(onGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  test('onGenerate throwing does not crash the component', () => {
+    const onGenerate = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const { container, api } = mount(onGenerate);
+    api.setHasMaster(true);
+    api.setEnabled(true);
+    const btn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="generate-btn"]',
+    )!;
+
+    // Should NOT propagate — component catches + console.errors.
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    expect(() => btn.click()).not.toThrow();
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});
+
+describe('generateButton — destroy', () => {
+  test('destroy removes the element + detaches the click listener', () => {
+    const onGenerate = vi.fn();
+    const { container, api } = mount(onGenerate);
+    api.setHasMaster(true);
+    api.setEnabled(true);
+
+    const btn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="generate-btn"]',
+    )!;
+    // Keep a reference to the detached node so we can try to click it post-
+    // destroy without querying (it won't be in the container anymore).
+    const detachedRef = btn;
+
+    api.destroy();
+
+    expect(
+      container.querySelector('[data-testid="generate-block"]'),
+    ).toBeNull();
+
+    // The click listener was removed — dispatching a click on the orphan
+    // element shouldn't invoke the handler.
+    detachedRef.dispatchEvent(new Event('click', { bubbles: true }));
+    expect(onGenerate).not.toHaveBeenCalled();
+  });
+});
+
+describe('generateButton — i18n', () => {
+  test('button label, hint, and ready text all resolve through i18next', () => {
+    const { container, api } = mount();
+
+    // Disabled + no master state.
+    const btn = container.querySelector('[data-testid="generate-btn"]')!;
+    expect(btn.textContent).toBe(i18next.t('generate.button'));
+    let hint = container.querySelector('[data-testid="generate-hint"]')!;
+    expect(hint.textContent).toBe(i18next.t('generate.noMaster'));
+
+    // Disabled + has master state.
+    api.setHasMaster(true);
+    hint = container.querySelector('[data-testid="generate-hint"]')!;
+    expect(hint.textContent).toBe(i18next.t('generate.hint'));
+
+    // Enabled state.
+    api.setEnabled(true);
+    hint = container.querySelector('[data-testid="generate-hint"]')!;
+    expect(hint.textContent).toBe(i18next.t('generate.ready'));
+  });
+});

--- a/tests/visual/generate-button-states.spec.ts
+++ b/tests/visual/generate-button-states.spec.ts
@@ -1,0 +1,144 @@
+// tests/visual/generate-button-states.spec.ts
+//
+// Visual regression: the sidebar Generate-mold block in its three visible
+// states (issue #36).
+//
+//   - Disabled + no master: hint reads "Load an STL to begin.". This is
+//     also the default first-launch view.
+//   - Disabled + master loaded: hint reads the orient-first instruction.
+//   - Enabled (orientation committed): button accent-coloured, hint reads
+//     "Ready to generate".
+//
+// We drive the state through `window.__testHooks.generateButton` plus the
+// master/controller hooks so each snapshot is deterministic without
+// simulating pointer events inside a SwiftShader-backed Chromium.
+//
+// First-run behaviour: these specs will produce new goldens on their
+// first green CI run. Per ADR-003 §B the visual-regression job is
+// advisory for 2 weeks after first green, so the missing-golden
+// failure does not block PR merge.
+
+import { expect, test, type Page } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const RENDERER_URL = 'http://localhost:5174/?test=1';
+const FIXTURE_PATH = resolve(
+  __dirname,
+  '..',
+  'fixtures',
+  'meshes',
+  'mini-figurine.stl',
+);
+
+async function openRenderer(page: Page): Promise<void> {
+  await page.clock.install({ time: new Date('2026-04-18T00:00:00Z') });
+  await page.addInitScript(() => {
+    (window as unknown as { api: Record<string, unknown> }).api = {
+      getVersion: () => Promise.resolve('0.0.0'),
+      openStl: () =>
+        Promise.resolve({ canceled: true, paths: [] as string[] }),
+      saveStl: () => Promise.resolve({ canceled: true }),
+    };
+    try {
+      window.localStorage.removeItem('units');
+    } catch {
+      /* ignore */
+    }
+  });
+  await page.goto(RENDERER_URL);
+  // Wait for the generate block (last thing to mount in the sidebar).
+  await page.waitForSelector('[data-testid="generate-btn"]', {
+    timeout: 10_000,
+  });
+  await page.waitForFunction(
+    () =>
+      !!(
+        window as unknown as {
+          __testHooks?: { generateButton?: unknown; parameters?: unknown };
+        }
+      ).__testHooks?.generateButton,
+    undefined,
+    { timeout: 10_000 },
+  );
+  await page.clock.runFor(100);
+}
+
+async function loadFixtureAsMaster(page: Page): Promise<void> {
+  const fixtureBytes = readFileSync(FIXTURE_PATH);
+  const byteArray = Array.from(fixtureBytes);
+  await page.evaluate(async (bytes: number[]) => {
+    const u8 = new Uint8Array(bytes);
+    const ab = u8.buffer.slice(u8.byteOffset, u8.byteOffset + u8.byteLength);
+    const hooks = (
+      window as unknown as {
+        __testHooks?: {
+          viewport?: { setMaster: (buf: ArrayBuffer) => Promise<unknown> };
+          generateButton?: { setHasMaster: (v: boolean) => void };
+        };
+      }
+    ).__testHooks;
+    if (!hooks?.viewport) throw new Error('viewport hook missing');
+    await hooks.viewport.setMaster(ab);
+    // main.ts only calls `setHasMaster(true)` from the Open-STL IPC path.
+    // Since the visual spec bypasses IPC (no real file dialog in Chromium),
+    // drive the hint state directly via the generate-button hook.
+    hooks.generateButton?.setHasMaster(true);
+  }, byteArray);
+  await page.clock.runFor(100);
+}
+
+test.describe('visual — generate-mold button states', () => {
+  test('disabled + no master: hint reads "Load an STL to begin."', async ({
+    page,
+  }) => {
+    await openRenderer(page);
+    await expect(page).toHaveScreenshot('generate-block-no-master.png', {
+      maxDiffPixelRatio: 0.01,
+      threshold: 0.15,
+      animations: 'disabled',
+      fullPage: false,
+    });
+  });
+
+  test('disabled + master loaded: hint reads the orient-first instruction', async ({
+    page,
+  }) => {
+    await openRenderer(page);
+    await loadFixtureAsMaster(page);
+    await expect(page).toHaveScreenshot('generate-block-disabled-with-master.png', {
+      maxDiffPixelRatio: 0.01,
+      threshold: 0.15,
+      animations: 'disabled',
+      fullPage: false,
+    });
+  });
+
+  test('enabled (committed): button accent-coloured + hint = "Ready to generate"', async ({
+    page,
+  }) => {
+    await openRenderer(page);
+    await loadFixtureAsMaster(page);
+    // Flip the generate button's enabled state directly via its test hook,
+    // short-circuiting the lay-flat commit pipeline (which is verified
+    // separately in `tests/e2e/generate-gate.spec.ts`). The visual under
+    // test is purely the button's enabled rendering.
+    await page.evaluate(() => {
+      const hooks = (
+        window as unknown as {
+          __testHooks?: {
+            generateButton?: { setEnabled: (v: boolean) => void };
+          };
+        }
+      ).__testHooks;
+      hooks?.generateButton?.setEnabled(true);
+    });
+    await page.clock.runFor(50);
+    await expect(page).toHaveScreenshot('generate-block-enabled.png', {
+      maxDiffPixelRatio: 0.01,
+      threshold: 0.15,
+      animations: 'disabled',
+      fullPage: false,
+    });
+  });
+});


### PR DESCRIPTION
# Summary

Ships the Phase 3c wave-1 UX gate (#36): mold generation is an explicit
button action, gated behind a committed lay-flat orientation. Adds a
Generate-mold block at the TOP of the right sidebar, new
`LAY_FLAT_COMMITTED_EVENT` plumbing, and wires the two together. Click
handler is a console.log stub pending #37.

## Linked issue

Closes #36

## Acceptance criteria (from the issue)

- [x] Right sidebar shows "Generate mold" button at the top, above the parameter form.
- [x] On app launch (no master loaded): button disabled; hint shows "Load an STL to begin." (documented variant — the "no master" case was an explicit design choice; issue wording allowed either omission or a variant).
- [x] After Open STL: button disabled; hint visible ("Orient the part on its base...").
- [x] After user commits a face via Place-on-face: button enabled; hint replaced with "Ready to generate".
- [x] After user clicks Reset orientation: button re-disabled; hint re-shown.
- [x] After Open STL loads a new master: button re-disabled (inherited commit state does not carry over); hint re-shown.
- [x] Clicking Generate (enabled state only) logs the expected payload to console. No unhandled promise rejection. No DOM state change for now.
- [x] `LAY_FLAT_COMMITTED_EVENT` fires at the three moments above; event handler in `main.ts` drives `setEnabled`.
- [x] `MountedViewport.isOrientationCommitted()` is exported and reflects the state.
- [x] Keyboard: button is Tab-focusable; Enter/Space activates it when enabled (native `<button>` semantics).
- [x] Dark theme parity — reuse `--accent`, `--bg`, `--border`, `--muted` tokens. No new colour tokens.
- [x] Unit test (happy-dom): `generateButton.setEnabled(true)` flips aria-disabled + clickable; click when disabled is a no-op.
- [x] Unit test: `layFlatController` dispatches `LAY_FLAT_COMMITTED_EVENT` with correct detail on commit/reset/new-master.
- [x] E2E Playwright: load mini-figurine -> assert button disabled + hint visible -> enable picking -> click canvas to commit -> assert button enabled + "Ready" text -> click Reset -> assert disabled again.
- [x] Visual regression: whole-app snapshot with button visible in both disabled and enabled states (three shots: no-master, disabled-with-master, enabled).

## What I did

- `src/renderer/ui/generateButton.ts` (new): mounts the `<div class="generate-block">` with button + hint. `setEnabled(bool)` + `setHasMaster(bool)` drive the three-state render. Exposes `.element` for external placement so `main.ts` can `prepend` it above the parameter form.
- `src/renderer/scene/layFlatController.ts`: new `LAY_FLAT_COMMITTED_EVENT` constant + private `committed` flag. `commit()` flips true + emits, `reset()` flips false + emits, new `notifyMasterReset()` flips false + emits. Emissions only fire on true state transitions (no spurious events).
- `src/renderer/scene/viewport.ts`: `MountedViewport.isOrientationCommitted()` passthrough; `setMaster` calls `layFlat.notifyMasterReset()` so new loads re-lock the gate.
- `src/renderer/main.ts`: mounts the generate-block, subscribes to `LAY_FLAT_COMMITTED_EVENT`, flips `setHasMaster(true)` on Open STL success. Stub `onGenerate` reads `quaternion` from the master group + `parametersStore.get()` and `console.log`s the payload. TODO-marked for #37 replacement.
- `src/renderer/index.html`: CSS for `.generate-block{,__button,__hint,__hint--ready}`. Reuses existing tokens.
- `src/renderer/i18n/en.json`: new `generate.{button,hint,ready,noMaster}` keys.
- Tests: 15 unit tests for the button component, 8 for the controller event contract, 2 Playwright e2e flows, 3 visual goldens.

## Test results

- [x] `pnpm lint` - green
- [x] `pnpm typecheck` - green
- [x] `pnpm test` - green (184 pass, 1 skipped, no new failures)
- [ ] `pnpm test:e2e` - not run locally (CI will run on windows-latest)
- [x] New unit tests added for changed behaviour
- [x] No STL snapshots changed (pure UI + event plumbing)

## Screenshots / GIFs

New visual specs produce three goldens on first CI green (advisory per ADR-003 for the first 2 weeks):
- `generate-block-no-master.png`
- `generate-block-disabled-with-master.png`
- `generate-block-enabled.png`

The existing `sidebar-parameters-*` goldens will regenerate with the new generate-block at the top — expected diff (scope-correct per issue).

## QA sign-off

- [ ] `qa-engineer` reviewed and approved
- [ ] Visual regression diff reviewed (if present) - acceptable / intentional

## Checklist

- [x] Units: no new numbers in user-visible text; internal state stays in its existing mm basis
- [x] i18n: all user-visible strings routed through `i18next` (`generate.*` keys)
- [x] Secrets: no new credentials, tokens, or private keys
- [x] No new env vars
- [ ] `docs/status.md` updated - deferred to lead's post-merge closeout per Phase 3c orchestration model
- [x] CLAUDE.md still accurate - no decisions contradicted

## Coordination with #37

`onGenerate` ships as a console.log stub. The geometry PR (#37) will replace the stub with `generateSiliconeShell(master, parameters, groupQuaternion)` once that PR merges. File ownership is disjoint per issue #36 - no overlap expected.

## Agent attribution

Primary author: `frontend-dev`
Reviewed by: `qa-engineer` (pending)