### PR TITLE
fix(ui): distinct placeholder for silicone/resin when not yet generated

### DIFF
--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -1,7 +1,8 @@
 {
   "volume": {
     "label": "Volume",
-    "none": "No master loaded"
+    "none": "No master loaded",
+    "notGenerated": "Click Generate"
   },
   "units": {
     "mm": "mm",

--- a/src/renderer/ui/formatters.ts
+++ b/src/renderer/ui/formatters.ts
@@ -54,14 +54,23 @@ const IN3_FORMATTER = new Intl.NumberFormat('en-US', {
 /**
  * Format a volume for display in the topbar.
  *
- * @param mm3  Volume in mm³, or `null` for the "no master loaded" state.
- * @param unit The unit system to render — 'mm' → "X mm³", 'in' → "Y in³".
+ * @param mm3      Volume in mm³, or `null` for the empty state.
+ * @param unit     The unit system to render — 'mm' → "X mm³", 'in' → "Y in³".
+ * @param emptyKey i18n key to use for the empty-state placeholder. Defaults
+ *                 to `'volume.none'` ("No master loaded"). Pass
+ *                 `'volume.notGenerated'` for silicone / resin slots, where
+ *                 a null value means "master loaded but not generated yet",
+ *                 NOT "master missing".
  *
  * @returns    Human-readable, locale-formatted string. Never throws.
  */
-export function formatVolume(mm3: number | null, unit: UnitSystem): string {
+export function formatVolume(
+  mm3: number | null,
+  unit: UnitSystem,
+  emptyKey: string = 'volume.none',
+): string {
   if (mm3 === null || !Number.isFinite(mm3)) {
-    return t('volume.none');
+    return t(emptyKey);
   }
 
   if (unit === 'in') {

--- a/src/renderer/ui/topbar.ts
+++ b/src/renderer/ui/topbar.ts
@@ -182,9 +182,21 @@ export function mountTopbar(
   const toggle: UnitsToggleApi = mountUnitsToggle(togglePanel);
 
   function renderAll(): void {
+    // Master uses the default "No master loaded" placeholder — a null value
+    // genuinely means no STL is open. Silicone + resin use "Click Generate"
+    // because they are null whenever the user hasn't run Generate yet,
+    // regardless of master state (loaded or not).
     master.valueEl.textContent = formatVolume(currentMaster, currentUnits);
-    silicone.valueEl.textContent = formatVolume(currentSilicone, currentUnits);
-    resin.valueEl.textContent = formatVolume(currentResin, currentUnits);
+    silicone.valueEl.textContent = formatVolume(
+      currentSilicone,
+      currentUnits,
+      'volume.notGenerated',
+    );
+    resin.valueEl.textContent = formatVolume(
+      currentResin,
+      currentUnits,
+      'volume.notGenerated',
+    );
   }
 
   // Listen for unit changes fired by the toggle (or by another component)
@@ -212,11 +224,16 @@ export function mountTopbar(
       silicone.valueEl.textContent = formatVolume(
         currentSilicone,
         currentUnits,
+        'volume.notGenerated',
       );
     },
     setResinVolume(mm3: number | null): void {
       currentResin = mm3;
-      resin.valueEl.textContent = formatVolume(currentResin, currentUnits);
+      resin.valueEl.textContent = formatVolume(
+        currentResin,
+        currentUnits,
+        'volume.notGenerated',
+      );
     },
     setUnits(unit: UnitSystem): void {
       toggle.setUnits(unit);

--- a/tests/e2e/generate-wire-up.spec.ts
+++ b/tests/e2e/generate-wire-up.spec.ts
@@ -179,9 +179,9 @@ test('generate wire-up: click → volumes populate → re-commit → volumes sta
 
     // Precondition: silicone + resin readouts exist and show the placeholder.
     await expect(page.locator('[data-testid="silicone-volume-value"]'))
-      .toHaveText('No master loaded');
+      .toHaveText('Click Generate');
     await expect(page.locator('[data-testid="resin-volume-value"]'))
-      .toHaveText('No master loaded');
+      .toHaveText('Click Generate');
 
     const openBtn = page.locator('[data-testid="open-stl-btn"]');
     await expect(openBtn).toBeVisible();
@@ -209,9 +209,9 @@ test('generate wire-up: click → volumes populate → re-commit → volumes sta
     await expect(page.locator('[data-testid="volume-value"]'))
       .not.toHaveText('No master loaded');
     await expect(page.locator('[data-testid="silicone-volume-value"]'))
-      .toHaveText('No master loaded');
+      .toHaveText('Click Generate');
     await expect(page.locator('[data-testid="resin-volume-value"]'))
-      .toHaveText('No master loaded');
+      .toHaveText('Click Generate');
 
     // Commit a face → Generate button enables.
     await commitTopFace(page);
@@ -317,9 +317,9 @@ test('generate wire-up: click → volumes populate → re-commit → volumes sta
     // transform so it stays populated.
     await commitSideFace(page);
     await expect(page.locator('[data-testid="silicone-volume-value"]'))
-      .toHaveText('No master loaded');
+      .toHaveText('Click Generate');
     await expect(page.locator('[data-testid="resin-volume-value"]'))
-      .toHaveText('No master loaded');
+      .toHaveText('Click Generate');
     await expect(page.locator('[data-testid="volume-value"]'))
       .not.toHaveText('No master loaded');
 

--- a/tests/renderer/ui/topbar.test.ts
+++ b/tests/renderer/ui/topbar.test.ts
@@ -67,11 +67,15 @@ describe('topbar — three volume readouts', () => {
     );
   });
 
-  test('initial state: all three readouts show the "no master loaded" placeholder', () => {
+  test('initial state: master shows "no master loaded"; silicone + resin show "click generate"', () => {
+    // Silicone + resin use a different empty-state ("Click Generate") from
+    // master because a null value means "master loaded but not generated
+    // yet" — which is distinct from "no STL open".
     const header = mount();
     mountTopbar(header);
 
-    const placeholder = i18next.t('volume.none');
+    const noMaster = i18next.t('volume.none');
+    const notGenerated = i18next.t('volume.notGenerated');
     const master = header.querySelector<HTMLElement>(
       '[data-testid="volume-value"]',
     );
@@ -81,9 +85,9 @@ describe('topbar — three volume readouts', () => {
     const resin = header.querySelector<HTMLElement>(
       '[data-testid="resin-volume-value"]',
     );
-    expect(master?.textContent).toBe(placeholder);
-    expect(silicone?.textContent).toBe(placeholder);
-    expect(resin?.textContent).toBe(placeholder);
+    expect(master?.textContent).toBe(noMaster);
+    expect(silicone?.textContent).toBe(notGenerated);
+    expect(resin?.textContent).toBe(notGenerated);
   });
 });
 
@@ -100,7 +104,7 @@ describe('topbar — setSiliconeVolume / setResinVolume', () => {
     expect(silicone?.textContent).toBe('100,000 mm\u00B3');
   });
 
-  test('setSiliconeVolume(null) reverts to placeholder', () => {
+  test('setSiliconeVolume(null) reverts to "click generate" placeholder', () => {
     const header = mount();
     const api = mountTopbar(header);
     api.setUnits('mm');
@@ -110,7 +114,7 @@ describe('topbar — setSiliconeVolume / setResinVolume', () => {
     const silicone = header.querySelector<HTMLElement>(
       '[data-testid="silicone-volume-value"]',
     );
-    expect(silicone?.textContent).toBe(i18next.t('volume.none'));
+    expect(silicone?.textContent).toBe(i18next.t('volume.notGenerated'));
   });
 
   test('setResinVolume(127_451.6) renders "127,452 mm³" (rounded)', () => {
@@ -125,7 +129,7 @@ describe('topbar — setSiliconeVolume / setResinVolume', () => {
     expect(resin?.textContent).toBe('127,452 mm\u00B3');
   });
 
-  test('setResinVolume(null) reverts to placeholder', () => {
+  test('setResinVolume(null) reverts to "click generate" placeholder', () => {
     const header = mount();
     const api = mountTopbar(header);
     api.setResinVolume(5000);
@@ -134,7 +138,7 @@ describe('topbar — setSiliconeVolume / setResinVolume', () => {
     const resin = header.querySelector<HTMLElement>(
       '[data-testid="resin-volume-value"]',
     );
-    expect(resin?.textContent).toBe(i18next.t('volume.none'));
+    expect(resin?.textContent).toBe(i18next.t('volume.notGenerated'));
   });
 
   test('the three setters are independent (setting one does not clobber the others)', () => {


### PR DESCRIPTION
## Summary

User live-dogfood feedback on the merged wire-up (#41): after loading an STL, the Silicone and Resin topbar slots said **\"No master loaded\"** — which reads as a lie because the master IS loaded, just not generated yet.

Fix: \`formatVolume\` accepts an optional i18n \`emptyKey\` override. Topbar passes \`volume.notGenerated\` (\"Click Generate\") for Silicone + Resin; Master keeps \`volume.none\` (\"No master loaded\") because a null master genuinely means no STL is open.

## Changes

- Added \`volume.notGenerated\` i18n key: \"Click Generate\".
- Extended \`formatVolume(mm3, unit, emptyKey?)\` — backwards compatible, default is \`'volume.none'\`.
- \`topbar.ts\` passes \`'volume.notGenerated'\` for silicone + resin in \`renderAll\`, \`setSiliconeVolume\`, \`setResinVolume\`.
- Updated 3 unit tests + 1 E2E group to expect the new placeholder.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` green (222 passed, 1 skipped — same count as post-#41 baseline)
- [ ] CI: lint + typecheck, geometry unit, windows e2e + visual smoke