### PR TITLE
feat(app): drag-drop STL onto window (#27)

### DIFF
--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -47,5 +47,11 @@
     "ready": "Ready to generate",
     "noMaster": "Load an STL to begin.",
     "error": "Could not generate mold: {{reason}}"
+  },
+  "errors": {
+    "stlOnly": "Only .stl files are supported",
+    "singleFile": "Drop one file at a time",
+    "fileTooLarge": "File too large",
+    "readFailed": "Could not read file"
   }
 }

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -300,6 +300,54 @@
         opacity: 0.5;
         cursor: not-allowed;
       }
+      /* ---- Drag-and-drop STL overlay (issue #27) ------------------------ */
+      /*
+       * Drawn as an inset outline on #app while a drag-with-files is live.
+       * `box-shadow: inset` sidesteps layout thrash (no border added, no
+       * reflow); the accent ring sits inside the window edge. The drop zone
+       * covers the entire app surface, so the highlight has to flow through
+       * the root wrapper — applying it to the viewport alone would miss
+       * drops over the sidebar / topbar.
+       */
+      #app.dropzone--active {
+        box-shadow: inset 0 0 0 3px var(--accent);
+      }
+      #app.dropzone--active #viewport::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        /* Subtle accent tint over the WebGL canvas so the user sees the
+           viewport acknowledging the drop target even when their cursor is
+           over the canvas rather than the chrome. */
+        background: rgba(74, 158, 255, 0.06);
+      }
+      /* ---- Error toast (issue #27 consolidates user-visible errors) ----- */
+      #app-error-toast {
+        position: fixed;
+        left: 50%;
+        bottom: 24px;
+        transform: translateX(-50%);
+        /* Reuse the parameter-form error red. Kept inline — promoting to a
+           --error-color token is the same trade-off called out in the
+           generate-block hint rules above: only a couple of sites. */
+        background: #e06c75;
+        color: #0b0d10;
+        padding: 8px 16px;
+        border-radius: 6px;
+        font-size: 13px;
+        font-weight: 500;
+        max-width: 480px;
+        text-align: center;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+        opacity: 0;
+        pointer-events: none;
+        z-index: 1000;
+        transition: opacity 0.15s ease-out;
+      }
+      #app-error-toast.is-visible {
+        opacity: 1;
+      }
     </style>
   </head>
   <body>

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -27,11 +27,13 @@ import { generateSiliconeShell } from '@/geometry/generateMold';
 import { LAY_FLAT_ACTIVE_EVENT } from './scene/layFlatController';
 import { getMasterManifold } from './scene/master';
 import { mount, type MountedViewport } from './scene/viewport';
-import { initI18n } from './i18n';
+import { initI18n, t } from './i18n';
 import {
   createParametersStore,
   type ParametersStore,
 } from './state/parameters';
+import { attachDropZone } from './ui/dropZone';
+import { clear as clearErrorToast, showError } from './ui/errorToast';
 import { bumpGenerateEpoch } from './ui/generateEpoch';
 import {
   mountGenerateButton,
@@ -239,10 +241,71 @@ function mountParameters(): void {
 }
 
 /**
+ * Shared post-load plumbing used by both the Open-STL dialog flow and the
+ * drag-drop-STL flow (issue #27). Given a raw STL `ArrayBuffer`, hands it
+ * to the viewport and then runs the identical stale-invalidation sweep:
+ *
+ *   - bumps the generate-epoch (drops any in-flight generate result),
+ *   - pushes the new master volume + nulls silicone / resin readouts,
+ *   - clears any residual generate-error + busy state,
+ *   - re-enables + resets the Place-on-face toggle,
+ *   - flips the Generate-block hint to "orient first".
+ *
+ * Errors bubble up — callers decide whether to surface them via the
+ * shared error-toast channel (`showError`) or swallow them.
+ */
+async function loadMasterFromBuffer(buffer: ArrayBuffer): Promise<void> {
+  if (!viewport) {
+    throw new Error('viewport not mounted yet');
+  }
+  const result = await viewport.setMaster(buffer);
+  // Bump the shared generate-epoch so any in-flight run against the
+  // previous master drops its result on resolve. `notifyMasterReset`
+  // only fires a committed-event when a commit was previously live, so
+  // the invalidation listener covers only the "had-commit → new-STL"
+  // path. Bumping here covers the first-load / no-prior-commit path too.
+  bumpGenerateEpoch();
+  if (topbar) {
+    topbar.setMasterVolume(result.volume_mm3);
+    // Any previously-populated silicone + resin values are for the OLD
+    // master and must be cleared. The lay-flat controller's
+    // `notifyMasterReset` will also fire a committed-event that clears
+    // them, but only when a commit was previously live — belt-and-
+    // braces here covers the first-load case and any defensive UI state.
+    topbar.setSiliconeVolume(null);
+    topbar.setResinVolume(null);
+  }
+  // Clear any residual error from a previous generate attempt.
+  if (generateButton) {
+    generateButton.setError(null);
+    generateButton.setBusy(false);
+  }
+  // Enable the lay-flat controls now that a master is in the scene.
+  // `setMaster` resets the master group to identity rotation, so the
+  // toggle must read "not active" regardless of its previous state.
+  if (placeOnFace) {
+    placeOnFace.setEnabled(true);
+    placeOnFace.setActive(false);
+  }
+  // Flip the Generate-block's hint from "Load an STL to begin." to
+  // "Orient the part on its base...". The button stays disabled — the
+  // LAY_FLAT_COMMITTED_EVENT subscription in `mountParameters()` will
+  // re-enable it after a commit. `viewport.setMaster` already called
+  // `layFlat.notifyMasterReset()`, which fires committed=false, so any
+  // stale enabled state from a previous master is cleared.
+  if (generateButton) {
+    generateButton.setHasMaster(true);
+  }
+  // A successful load supersedes any lingering error banner (e.g. the
+  // user hit "file too large" and then picked a valid file).
+  clearErrorToast();
+}
+
+/**
  * Open the native STL file dialog, stream the bytes back over IPC, and
- * hand the buffer to the viewport. Updates the topbar volume readout on
- * success. Logs errors to console — a user-visible toast is later work
- * (see issue #16 scope).
+ * hand the buffer to the shared post-load path. User-visible errors are
+ * surfaced via the consolidated error-toast channel (shared with the
+ * drag-drop flow, issue #27).
  *
  * Re-entrancy: while an open is in flight, the Open STL button is
  * disabled so a double-click doesn't stack two loads. Once the flow
@@ -261,16 +324,19 @@ async function handleOpenStl(button: HTMLButtonElement): Promise<void> {
       return;
     }
     if ('error' in response) {
-      // Typed error variant from the main process. Only `file-too-large`
-      // exists at the moment; switch handles future additions exhaustively.
+      // Typed error variant from the main process. Route each through the
+      // shared error-toast channel; the switch stays exhaustive so future
+      // variants will surface a compile error here until localised.
       switch (response.error) {
         case 'file-too-large':
           console.error(
             '[open-stl] selected STL exceeds the 500 MB size limit',
           );
+          showError(t('errors.fileTooLarge'));
           break;
         case 'read-failed':
           console.error('[open-stl] failed to read selected STL file');
+          showError(t('errors.readFailed'));
           break;
         default: {
           const exhaustive: never = response.error;
@@ -281,53 +347,50 @@ async function handleOpenStl(button: HTMLButtonElement): Promise<void> {
     }
 
     // Success path — `response.buffer` is an ArrayBuffer of the STL bytes
-    // (see shared/ipc-contracts.ts, structured-cloned across IPC). Hand it
-    // to the viewport; that module owns STL parsing, scene-swap, and
-    // camera framing. The returned volume_mm3 is the watertight manifold
-    // volume; feed it straight to the topbar.
-    const result = await viewport.setMaster(response.buffer);
-    // Bump the shared generate-epoch so any in-flight run against the
-    // previous master drops its result on resolve. `notifyMasterReset`
-    // only fires a committed-event when a commit was previously live, so
-    // the invalidation listener covers only the "had-commit → new-STL"
-    // path. Bumping here covers the first-load / no-prior-commit path too.
-    bumpGenerateEpoch();
-    if (topbar) {
-      topbar.setMasterVolume(result.volume_mm3);
-      // Any previously-populated silicone + resin values are for the OLD
-      // master and must be cleared. The lay-flat controller's
-      // `notifyMasterReset` will also fire a committed-event that clears
-      // them, but only when a commit was previously live — belt-and-
-      // braces here covers the first-load case and any defensive UI state.
-      topbar.setSiliconeVolume(null);
-      topbar.setResinVolume(null);
-    }
-    // Clear any residual error from a previous generate attempt.
-    if (generateButton) {
-      generateButton.setError(null);
-      generateButton.setBusy(false);
-    }
-    // Enable the lay-flat controls now that a master is in the scene.
-    // `setMaster` resets the master group to identity rotation, so the
-    // toggle must read "not active" regardless of its previous state.
-    if (placeOnFace) {
-      placeOnFace.setEnabled(true);
-      placeOnFace.setActive(false);
-    }
-    // Flip the Generate-block's hint from "Load an STL to begin." to
-    // "Orient the part on its base...". The button stays disabled — the
-    // LAY_FLAT_COMMITTED_EVENT subscription in `mountParameters()` will
-    // re-enable it after a commit. `viewport.setMaster` already called
-    // `layFlat.notifyMasterReset()`, which fires committed=false, so any
-    // stale enabled state from a previous master is cleared.
-    if (generateButton) {
-      generateButton.setHasMaster(true);
-    }
+    // (see shared/ipc-contracts.ts, structured-cloned across IPC). Hand
+    // it to the shared post-load path so Open-STL and drag-drop stay in
+    // lock-step on state resets.
+    await loadMasterFromBuffer(response.buffer);
   } catch (err) {
     console.error('[open-stl] unexpected error during load:', err);
+    showError(t('errors.readFailed'));
   } finally {
     button.disabled = false;
   }
+}
+
+/**
+ * Wire the window-scoped drag-and-drop handler (issue #27). The target is
+ * the top-level `<div id="app">` wrapper so a drop anywhere inside the
+ * window is caught (viewport, sidebar, topbar). The handler goes through
+ * the HTML5 `File.arrayBuffer()` API — NOT `file.path` or any Node fs
+ * API — so the renderer's `contextIsolation` + `sandbox` boundary is
+ * preserved.
+ *
+ * Successful drops hit the same `loadMasterFromBuffer` path as the Open
+ * STL dialog, guaranteeing identical post-load state (epoch bump, stale
+ * invalidation, orientation reset, hint flip). Validation failures
+ * surface via the shared error toast.
+ */
+function wireDropZone(): void {
+  const app = document.getElementById('app');
+  if (!app) {
+    console.error('wireDropZone: #app container not found in DOM');
+    return;
+  }
+  attachDropZone(app, {
+    async onDrop(buffer) {
+      try {
+        await loadMasterFromBuffer(buffer);
+      } catch (err) {
+        console.error('[drop-stl] failed to load dropped STL:', err);
+        showError(t('errors.readFailed'));
+      }
+    },
+    onError(_code, message) {
+      showError(message);
+    },
+  });
 }
 
 /**
@@ -355,5 +418,6 @@ document.addEventListener('DOMContentLoaded', () => {
   mountViewport();
   mountParameters();
   wireOpenStlButton();
+  wireDropZone();
   void hydrateVersion();
 });

--- a/src/renderer/ui/dropZone.ts
+++ b/src/renderer/ui/dropZone.ts
@@ -1,0 +1,206 @@
+// src/renderer/ui/dropZone.ts
+//
+// Window-scoped STL drag-and-drop handler (issue #27).
+//
+// Responsibilities:
+//   - Attach `dragenter` / `dragover` / `dragleave` / `drop` listeners to
+//     the provided target element.
+//   - On drop, validate the payload and hand a single `ArrayBuffer` back
+//     to the caller via `onDrop`. Surface any validation failure via
+//     `onError(code, localisedMessage)` so the caller can route it through
+//     the shared error-toast channel.
+//   - Apply / remove the `.dropzone--active` class on the target element
+//     during a drag, wrapping a `dragenter`/`dragleave` counter so nested
+//     children (the Three.js canvas, sidebar inputs) don't flicker the
+//     outline off mid-drag.
+//
+// Security-critical constraints (see CLAUDE.md + docs/adr/001-platform.md):
+//   - The renderer MUST NOT read `file.path` or use any Node `fs` API. This
+//     module deliberately uses the HTML5 `File.arrayBuffer()` API, which
+//     returns the bytes without ever exposing the host filesystem path.
+//   - There is no new IPC channel — the dropped buffer reuses the same
+//     in-renderer code path the Open-STL dialog hands its buffer to.
+//
+// Validation (all fail fast; no state change on error):
+//   1. Zero files → no-op. `DataTransfer.files` may be empty for directory
+//      drops on some browsers; we treat that as "not a valid drop" rather
+//      than an explicit error to avoid a noisy toast on accidental drags.
+//   2. More than one file → `multiple-files` error.
+//   3. Extension not `.stl` (case-insensitive) → `wrong-extension` error.
+//   4. File size > `OPEN_STL_MAX_BYTES` → `file-too-large` error.
+//
+// The buffer is only read (via `file.arrayBuffer()`) after all validations
+// pass — oversized files don't get allocated just to be rejected.
+
+import { OPEN_STL_MAX_BYTES } from '@shared/ipc-contracts';
+import { t } from '../i18n';
+
+/**
+ * Discriminated error codes. Kept as string literals so the caller can
+ * switch exhaustively and the type checker will flag a missing case when
+ * a new validation rule is added.
+ */
+export type DropZoneErrorCode =
+  | 'multiple-files'
+  | 'wrong-extension'
+  | 'file-too-large'
+  | 'read-failed';
+
+export interface DropZoneCallbacks {
+  /**
+   * Fired when a validated single `.stl` file has been read into memory.
+   * The `name` is the file basename (no path, since we never see one).
+   */
+  onDrop(buffer: ArrayBuffer, name: string): void | Promise<void>;
+  /**
+   * Fired when validation rejects the drop. `code` is stable for tests;
+   * `message` is the already-localised copy ready for the user-facing
+   * error channel.
+   */
+  onError(code: DropZoneErrorCode, message: string): void;
+}
+
+export interface DropZoneApi {
+  /** Detach every listener and clear any lingering `.dropzone--active`. */
+  destroy(): void;
+}
+
+/** Resolved i18n message for a given error code. */
+function messageFor(code: DropZoneErrorCode): string {
+  switch (code) {
+    case 'multiple-files':
+      return t('errors.singleFile');
+    case 'wrong-extension':
+      return t('errors.stlOnly');
+    case 'file-too-large':
+      return t('errors.fileTooLarge');
+    case 'read-failed':
+      return t('errors.readFailed');
+    default: {
+      const exhaustive: never = code;
+      return String(exhaustive);
+    }
+  }
+}
+
+/** Case-insensitive `.stl` extension check on the file name. */
+function isStlFile(file: File): boolean {
+  return file.name.toLowerCase().endsWith('.stl');
+}
+
+/**
+ * Wire the drop-zone onto `target`. All listeners are bound with
+ * `preventDefault()` so the browser's default "navigate to file://…"
+ * behaviour cannot fire — that would otherwise replace the renderer
+ * document and crash the Electron window.
+ *
+ * `onDrop` is awaited (if it returns a promise) so async errors bubble
+ * into this module's `try/catch` and surface through `onError` rather
+ * than escaping as an unhandled rejection.
+ */
+export function attachDropZone(
+  target: HTMLElement,
+  callbacks: DropZoneCallbacks,
+): DropZoneApi {
+  // Nested `dragenter`/`dragleave` fire for every child element the cursor
+  // crosses over. Tracking the depth keeps the outline on for the entire
+  // drag and only removes it when the cursor truly leaves the window.
+  let dragDepth = 0;
+
+  const setActive = (active: boolean): void => {
+    if (active) {
+      target.classList.add('dropzone--active');
+    } else {
+      target.classList.remove('dropzone--active');
+    }
+  };
+
+  const onDragEnter = (event: DragEvent): void => {
+    // Only react to drags that carry files — ignore text/in-page drags.
+    if (!event.dataTransfer?.types?.includes('Files')) return;
+    event.preventDefault();
+    dragDepth += 1;
+    if (dragDepth === 1) setActive(true);
+  };
+
+  const onDragOver = (event: DragEvent): void => {
+    if (!event.dataTransfer?.types?.includes('Files')) return;
+    // preventDefault is REQUIRED on dragover to mark this element as a
+    // valid drop target; without it the subsequent `drop` event never
+    // fires. See HTML Living Standard §6.8.4.
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+  };
+
+  const onDragLeave = (event: DragEvent): void => {
+    if (!event.dataTransfer?.types?.includes('Files')) return;
+    event.preventDefault();
+    dragDepth = Math.max(0, dragDepth - 1);
+    if (dragDepth === 0) setActive(false);
+  };
+
+  const onDrop = async (event: DragEvent): Promise<void> => {
+    // Always prevent the default regardless of validation outcome: if the
+    // browser navigates to `file://…` we lose the entire app window.
+    event.preventDefault();
+    dragDepth = 0;
+    setActive(false);
+
+    const files = event.dataTransfer?.files;
+    if (!files || files.length === 0) {
+      // Directory drop (no File entries) or a spurious empty drop. No
+      // error toast — it would be noisy for a user-visible "nothing
+      // happened" outcome.
+      return;
+    }
+
+    if (files.length > 1) {
+      callbacks.onError('multiple-files', messageFor('multiple-files'));
+      return;
+    }
+
+    const file = files[0];
+    if (!file) return;
+
+    if (!isStlFile(file)) {
+      callbacks.onError('wrong-extension', messageFor('wrong-extension'));
+      return;
+    }
+
+    if (file.size > OPEN_STL_MAX_BYTES) {
+      callbacks.onError('file-too-large', messageFor('file-too-large'));
+      return;
+    }
+
+    try {
+      const buffer = await file.arrayBuffer();
+      await callbacks.onDrop(buffer, file.name);
+    } catch (err) {
+      console.error('[drop-zone] failed to read dropped file:', err);
+      callbacks.onError('read-failed', messageFor('read-failed'));
+    }
+  };
+
+  // The `drop` handler is async but EventListener expects a `void`-returning
+  // function. Wrap it so the returned Promise is fired-and-forgotten (errors
+  // inside `onDrop` are already caught and routed through `onError`).
+  const onDropListener = (ev: Event): void => {
+    void onDrop(ev as DragEvent);
+  };
+
+  target.addEventListener('dragenter', onDragEnter);
+  target.addEventListener('dragover', onDragOver);
+  target.addEventListener('dragleave', onDragLeave);
+  target.addEventListener('drop', onDropListener);
+
+  return {
+    destroy(): void {
+      target.removeEventListener('dragenter', onDragEnter);
+      target.removeEventListener('dragover', onDragOver);
+      target.removeEventListener('dragleave', onDragLeave);
+      target.removeEventListener('drop', onDropListener);
+      dragDepth = 0;
+      setActive(false);
+    },
+  };
+}

--- a/src/renderer/ui/errorToast.ts
+++ b/src/renderer/ui/errorToast.ts
@@ -1,0 +1,123 @@
+// src/renderer/ui/errorToast.ts
+//
+// Minimal singleton error-toast surface. A lazy-mounted `<div>` at the
+// bottom-centre of the window that shows a single user-visible error line
+// and fades out after a short timeout.
+//
+// Why build this instead of reusing the generate-button's `setError`? The
+// generate-block is sidebar-scoped and conveys "generate failed" semantics;
+// dropping a non-STL file has nothing to do with mold generation. The Open
+// STL flow has logged errors to `console.error` up to now (see the comment
+// on `handleOpenStl` in main.ts referencing issue #16 "user-visible toast
+// is later work"). Issue #27 now requires drag-drop to surface errors
+// user-visibly, so this is the consolidation the issue asks for: "Surface
+// errors ... via the same user-visible error channel the Open STL dialog
+// uses today — consolidate if there isn't one."
+//
+// Scope kept tight on purpose:
+//   - Single active message (new call replaces the current text; no queue).
+//   - Auto-dismisses after `TIMEOUT_MS`. Callers can force-clear via `clear()`.
+//   - No animation library; opacity transition via CSS in index.html.
+//   - No ARIA live-region politeness beyond role=alert — good enough for the
+//     brief, discrete failures this module currently handles.
+//
+// The overlay element is appended to `document.body` on first use and kept
+// across invocations (DOM-light; the fade-out transition relies on it
+// staying in the tree).
+
+const OVERLAY_ID = 'app-error-toast';
+const TIMEOUT_MS = 5000;
+
+let overlay: HTMLDivElement | null = null;
+let hideTimer: number | null = null;
+
+/**
+ * Ensure the overlay `<div>` is in the DOM and return it. Lazy-mount so
+ * this module has no side effects at import time — important for Vitest
+ * specs that import-and-discard without triggering a render.
+ */
+function ensureOverlay(): HTMLDivElement {
+  if (overlay && overlay.isConnected) return overlay;
+  const existing = document.getElementById(OVERLAY_ID);
+  if (existing instanceof HTMLDivElement) {
+    overlay = existing;
+    return overlay;
+  }
+  const el = document.createElement('div');
+  el.id = OVERLAY_ID;
+  el.setAttribute('role', 'alert');
+  el.setAttribute('aria-live', 'assertive');
+  el.dataset['testid'] = 'error-toast';
+  // Hidden by default; `.is-visible` flips display + opacity.
+  el.hidden = true;
+  document.body.appendChild(el);
+  overlay = el;
+  return el;
+}
+
+/**
+ * Show `message` in the overlay. Replaces any prior message and resets the
+ * auto-dismiss timer. Passing an empty string is treated as `clear()`.
+ */
+export function showError(message: string): void {
+  if (!message) {
+    clear();
+    return;
+  }
+  const el = ensureOverlay();
+  el.textContent = message;
+  el.hidden = false;
+  // Force reflow so the transition reruns when two errors land back-to-back.
+  el.classList.remove('is-visible');
+  void el.offsetWidth;
+  el.classList.add('is-visible');
+
+  if (hideTimer !== null) {
+    window.clearTimeout(hideTimer);
+  }
+  hideTimer = window.setTimeout(() => {
+    clear();
+  }, TIMEOUT_MS);
+}
+
+/**
+ * Force-clear the overlay immediately. Safe to call when nothing is showing.
+ * Used by callers that want to wipe stale state before triggering a new
+ * action (e.g. a successful load should clear any lingering error banner).
+ */
+export function clear(): void {
+  if (hideTimer !== null) {
+    window.clearTimeout(hideTimer);
+    hideTimer = null;
+  }
+  if (!overlay) return;
+  overlay.classList.remove('is-visible');
+  overlay.hidden = true;
+  overlay.textContent = '';
+}
+
+/**
+ * Read the current error text (empty string when hidden). Intended for
+ * tests — the DOM is the source of truth, but this keeps specs from
+ * reaching into the internal module state.
+ */
+export function currentMessage(): string {
+  if (!overlay || overlay.hidden) return '';
+  return overlay.textContent ?? '';
+}
+
+/**
+ * Test-only reset: detaches the overlay and wipes internal state. The
+ * lazy-mount path will re-create it on the next `showError`. Not exported
+ * from the public barrel; imported directly by unit tests.
+ */
+export function __resetForTests(): void {
+  if (hideTimer !== null) {
+    window.clearTimeout(hideTimer);
+    hideTimer = null;
+  }
+  if (overlay && overlay.parentElement) {
+    overlay.parentElement.removeChild(overlay);
+  }
+  overlay = null;
+}

--- a/tests/e2e/drag-drop-stl.spec.ts
+++ b/tests/e2e/drag-drop-stl.spec.ts
@@ -1,0 +1,271 @@
+// tests/e2e/drag-drop-stl.spec.ts
+//
+// End-to-end coverage for issue #27 (drag-drop STL onto the window).
+//
+// What this exercises:
+//   - A programmatic drop event synthesised inside the renderer — we
+//     can't drive the host OS drag layer from Playwright/Electron, so we
+//     construct a DragEvent with a DataTransfer carrying a real `File`
+//     built from the fixture bytes. This is the same entry point the
+//     production drop handler sees from a real OS drag.
+//   - Post-load state parity with the Open-STL dialog flow: a `master`
+//     mesh enters the scene + the topbar volume readout shows a real
+//     value. Mirrors `tests/e2e/load-stl-flow.spec.ts` so a drift in
+//     loadMasterFromBuffer between the two entrypoints would fail both.
+//   - Error-toast surfacing for the three validation rules:
+//     wrong-extension, multi-file, too-large.
+//
+// Why Chromium synthesis and not the real drag layer: Playwright's
+// `page.dispatchEvent` can't construct a DataTransfer with files; the
+// community pattern is to build the DragEvent inside the page via
+// `page.evaluate` (see microsoft/playwright#2136). This matches how
+// real browser tests for drag-and-drop work.
+
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { launchApp } from './fixtures/app';
+
+const UNIT_CUBE_PATH = resolve(
+  __dirname,
+  '..',
+  'fixtures',
+  'meshes',
+  'unit-cube.stl',
+);
+
+test('drag-drop: single .stl loads identically to Open-STL dialog', async () => {
+  const app = await launchApp();
+  try {
+    const page = await app.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
+
+    page.on('console', (msg) => {
+      console.log(`[renderer:${msg.type()}] ${msg.text()}`);
+    });
+    page.on('pageerror', (err) => {
+      console.log(`[renderer:pageerror] ${err.message}`);
+    });
+
+    // Capture the masterLoaded promise BEFORE dropping — same pattern as
+    // load-stl-flow.spec.ts. The viewport rotates the promise on each
+    // successful load so this await covers exactly one load cycle.
+    await page.evaluate(() => {
+      const hooks = (
+        window as unknown as {
+          __testHooks?: { masterLoaded?: Promise<void> };
+        }
+      ).__testHooks;
+      if (!hooks?.masterLoaded) {
+        throw new Error(
+          'window.__testHooks.masterLoaded missing — NODE_ENV=test not honoured?',
+        );
+      }
+      (
+        globalThis as unknown as { __pendingMasterLoaded: Promise<void> }
+      ).__pendingMasterLoaded = hooks.masterLoaded;
+    });
+
+    // Read the STL bytes on the Node side and pass them through as a
+    // regular array (structured-clone over the CDP boundary). The renderer
+    // reassembles a File/DataTransfer and dispatches the DragEvent on
+    // `#app`, which is where `attachDropZone` listens.
+    const stlBytes = Array.from(readFileSync(UNIT_CUBE_PATH));
+
+    await page.evaluate(
+      ({ bytes, fileName }) => {
+        const buffer = new Uint8Array(bytes);
+        const file = new File([buffer], fileName, { type: 'model/stl' });
+        const dt = new DataTransfer();
+        dt.items.add(file);
+
+        const target = document.getElementById('app');
+        if (!target) throw new Error('#app container missing');
+
+        // Fire the standard drag sequence. dragenter + dragover must both
+        // preventDefault for the subsequent drop to be honoured; the
+        // handler does that internally.
+        const dragEnter = new DragEvent('dragenter', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        });
+        target.dispatchEvent(dragEnter);
+        const dragOver = new DragEvent('dragover', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        });
+        target.dispatchEvent(dragOver);
+        const drop = new DragEvent('drop', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        });
+        target.dispatchEvent(drop);
+      },
+      { bytes: stlBytes, fileName: 'unit-cube.stl' },
+    );
+
+    // Await the load. 30 s is generous — unit-cube is 12 tri, so really
+    // bounded by the manifold-3d init cost.
+    await page.evaluate(
+      () =>
+        (
+          globalThis as unknown as { __pendingMasterLoaded: Promise<void> }
+        ).__pendingMasterLoaded,
+    );
+
+    // A mesh tagged 'master' now lives in the scene — identical assertion
+    // to load-stl-flow.spec.ts, proving parity between the two entry points.
+    const hasMasterMesh = await page.evaluate(() => {
+      const scene = (
+        window as unknown as {
+          __testHooks?: {
+            scene?: {
+              traverse: (
+                cb: (o: {
+                  userData?: Record<string, unknown>;
+                  type?: string;
+                }) => void,
+              ) => void;
+            };
+          };
+        }
+      ).__testHooks?.scene;
+      if (!scene) return false;
+      let found = false;
+      scene.traverse((obj) => {
+        if (obj.userData?.['tag'] === 'master' && obj.type === 'Mesh') {
+          found = true;
+        }
+      });
+      return found;
+    });
+    expect(hasMasterMesh).toBe(true);
+
+    // Topbar master-volume readout shows a concrete value rather than the
+    // empty-state placeholder.
+    const volumeText = await page
+      .locator('[data-testid="volume-value"]')
+      .textContent();
+    expect(volumeText).toBeTruthy();
+    expect(volumeText).not.toBe('No master loaded');
+    expect(volumeText).toMatch(/mm\u00B3$/);
+  } finally {
+    await app.close();
+  }
+});
+
+test('drag-drop: wrong-extension surfaces the user-visible error', async () => {
+  const app = await launchApp();
+  try {
+    const page = await app.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.evaluate(() => {
+      const file = new File([new Uint8Array([1, 2, 3])], 'readme.txt', {
+        type: 'text/plain',
+      });
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      const target = document.getElementById('app');
+      if (!target) throw new Error('#app missing');
+      target.dispatchEvent(
+        new DragEvent('drop', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        }),
+      );
+    });
+
+    const toast = page.locator('[data-testid="error-toast"]');
+    await expect(toast).toBeVisible();
+    await expect(toast).toHaveText('Only .stl files are supported');
+
+    // No master in the scene — the topbar should still show the empty state.
+    await expect(page.locator('[data-testid="volume-value"]')).toHaveText(
+      'No master loaded',
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test('drag-drop: multi-file surfaces the user-visible error', async () => {
+  const app = await launchApp();
+  try {
+    const page = await app.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.evaluate(() => {
+      const dt = new DataTransfer();
+      dt.items.add(
+        new File([new Uint8Array([0])], 'a.stl', { type: 'model/stl' }),
+      );
+      dt.items.add(
+        new File([new Uint8Array([0])], 'b.stl', { type: 'model/stl' }),
+      );
+      const target = document.getElementById('app');
+      if (!target) throw new Error('#app missing');
+      target.dispatchEvent(
+        new DragEvent('drop', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        }),
+      );
+    });
+
+    const toast = page.locator('[data-testid="error-toast"]');
+    await expect(toast).toBeVisible();
+    await expect(toast).toHaveText('Drop one file at a time');
+    await expect(page.locator('[data-testid="volume-value"]')).toHaveText(
+      'No master loaded',
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test('drag-drop: oversized file surfaces the user-visible error', async () => {
+  const app = await launchApp();
+  try {
+    const page = await app.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.evaluate(() => {
+      // A File with a spoofed size > 500 MB. We can't actually allocate
+      // half a gig in a Playwright spec; the handler reads File.size,
+      // so overriding the property is enough to hit the too-large path.
+      const file = new File([new Uint8Array([0])], 'huge.stl', {
+        type: 'model/stl',
+      });
+      Object.defineProperty(file, 'size', {
+        value: 600 * 1024 * 1024,
+        writable: false,
+      });
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      const target = document.getElementById('app');
+      if (!target) throw new Error('#app missing');
+      target.dispatchEvent(
+        new DragEvent('drop', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        }),
+      );
+    });
+
+    const toast = page.locator('[data-testid="error-toast"]');
+    await expect(toast).toBeVisible();
+    await expect(toast).toHaveText('File too large');
+    await expect(page.locator('[data-testid="volume-value"]')).toHaveText(
+      'No master loaded',
+    );
+  } finally {
+    await app.close();
+  }
+});

--- a/tests/renderer/ui/dropZone.test.ts
+++ b/tests/renderer/ui/dropZone.test.ts
@@ -1,0 +1,265 @@
+// tests/renderer/ui/dropZone.test.ts
+//
+// @vitest-environment happy-dom
+//
+// Unit-level coverage for the drag-and-drop STL handler (issue #27).
+//
+// What this covers that the E2E spec does not:
+//   - The `dragenter` counter: the `.dropzone--active` class survives
+//     nested child enter/leave events (bug if the outline flickers off
+//     when the cursor crosses the WebGL canvas boundary).
+//   - Every validation rule (wrong extension, multi-file, too-large,
+//     zero-file) maps to the right error code + localised message.
+//   - The file is read via `File.arrayBuffer()` — i.e. the renderer-safe
+//     path, not `file.path`. A synthetic `File` with the host-forbidden
+//     `.path` property would *not* be consulted by production code.
+//   - `destroy()` removes listeners and clears the active-state class.
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { initI18n } from '@/renderer/i18n';
+import { attachDropZone } from '@/renderer/ui/dropZone';
+import { OPEN_STL_MAX_BYTES } from '@shared/ipc-contracts';
+
+/**
+ * Build a DragEvent with a synthetic DataTransfer. happy-dom doesn't ship
+ * a full DataTransfer implementation, so we fake only the two fields the
+ * handler reads: `types` and `files`. `dropEffect` is writable per the
+ * HTML spec and our handler sets it during dragover.
+ */
+function makeDragEvent(
+  type: 'dragenter' | 'dragover' | 'dragleave' | 'drop',
+  files: File[],
+  includeFilesType = true,
+): DragEvent {
+  const event = new Event(type, {
+    bubbles: true,
+    cancelable: true,
+  }) as DragEvent;
+  const fileList = {
+    length: files.length,
+    item: (i: number): File | null => files[i] ?? null,
+    [Symbol.iterator]: function* () {
+      for (const f of files) yield f;
+    },
+  } as unknown as FileList;
+  // Copy index accessors onto the FileList — downstream code indexes it.
+  for (let i = 0; i < files.length; i++) {
+    (fileList as unknown as Record<number, File>)[i] = files[i] as File;
+  }
+  const dataTransfer = {
+    types: includeFilesType ? ['Files'] : [],
+    files: fileList,
+    dropEffect: 'none',
+  } as unknown as DataTransfer;
+  Object.defineProperty(event, 'dataTransfer', {
+    value: dataTransfer,
+    writable: false,
+  });
+  return event;
+}
+
+/**
+ * Build a File whose `arrayBuffer()` returns a fresh buffer of the given
+ * byte length. Bytes are zeroed; the dropZone doesn't parse STL content.
+ */
+function makeFile(name: string, sizeBytes: number): File {
+  const bytes = new Uint8Array(Math.max(1, Math.min(sizeBytes, 1024)));
+  // Spoof `size` to allow "pretend to be huge" cases without allocating
+  // a gigabyte. Real File objects derive size from their body; happy-dom
+  // copies this flag through.
+  const file = new File([bytes], name, { type: 'model/stl' });
+  Object.defineProperty(file, 'size', { value: sizeBytes, writable: false });
+  return file;
+}
+
+let target: HTMLDivElement;
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  initI18n();
+});
+
+describe('dropZone — dragenter/dragleave highlight', () => {
+  test('adds .dropzone--active on first dragenter carrying files', () => {
+    attachDropZone(target, {
+      onDrop: vi.fn(),
+      onError: vi.fn(),
+    });
+    target.dispatchEvent(makeDragEvent('dragenter', [makeFile('x.stl', 10)]));
+    expect(target.classList.contains('dropzone--active')).toBe(true);
+  });
+
+  test('ignores drags without a Files type (pure text drag)', () => {
+    attachDropZone(target, {
+      onDrop: vi.fn(),
+      onError: vi.fn(),
+    });
+    target.dispatchEvent(
+      makeDragEvent('dragenter', [makeFile('x.stl', 10)], false),
+    );
+    expect(target.classList.contains('dropzone--active')).toBe(false);
+  });
+
+  test('nested enter/leave keeps outline on until depth returns to 0', () => {
+    attachDropZone(target, {
+      onDrop: vi.fn(),
+      onError: vi.fn(),
+    });
+    const f = [makeFile('x.stl', 10)];
+    // Three enters, two leaves — depth is still 1 → class stays on.
+    target.dispatchEvent(makeDragEvent('dragenter', f));
+    target.dispatchEvent(makeDragEvent('dragenter', f));
+    target.dispatchEvent(makeDragEvent('dragenter', f));
+    target.dispatchEvent(makeDragEvent('dragleave', f));
+    target.dispatchEvent(makeDragEvent('dragleave', f));
+    expect(target.classList.contains('dropzone--active')).toBe(true);
+    // Final leave drops depth to 0 → class removed.
+    target.dispatchEvent(makeDragEvent('dragleave', f));
+    expect(target.classList.contains('dropzone--active')).toBe(false);
+  });
+
+  test('drop removes the active class regardless of prior depth', async () => {
+    const onDrop = vi.fn();
+    attachDropZone(target, { onDrop, onError: vi.fn() });
+    const f = [makeFile('cube.stl', 64)];
+    target.dispatchEvent(makeDragEvent('dragenter', f));
+    target.dispatchEvent(makeDragEvent('dragenter', f));
+    target.dispatchEvent(makeDragEvent('drop', f));
+    // Yield to the async file.arrayBuffer() handler.
+    await Promise.resolve();
+    expect(target.classList.contains('dropzone--active')).toBe(false);
+  });
+});
+
+describe('dropZone — drop validation', () => {
+  test('single valid .stl resolves onDrop with an ArrayBuffer', async () => {
+    const onDrop = vi.fn();
+    attachDropZone(target, { onDrop, onError: vi.fn() });
+    const file = makeFile('cube.stl', 84);
+    target.dispatchEvent(makeDragEvent('drop', [file]));
+    // `file.arrayBuffer()` is a microtask; flush.
+    await new Promise<void>((r) => setTimeout(r, 0));
+    expect(onDrop).toHaveBeenCalledTimes(1);
+    const [buffer, name] = onDrop.mock.calls[0] ?? [];
+    expect(buffer).toBeInstanceOf(ArrayBuffer);
+    expect(name).toBe('cube.stl');
+  });
+
+  test('case-insensitive .STL extension is accepted', async () => {
+    const onDrop = vi.fn();
+    attachDropZone(target, { onDrop, onError: vi.fn() });
+    target.dispatchEvent(
+      makeDragEvent('drop', [makeFile('Cube.STL', 84)]),
+    );
+    await new Promise<void>((r) => setTimeout(r, 0));
+    expect(onDrop).toHaveBeenCalledTimes(1);
+  });
+
+  test('non-stl extension → wrong-extension error, no onDrop', async () => {
+    const onDrop = vi.fn();
+    const onError = vi.fn();
+    attachDropZone(target, { onDrop, onError });
+    target.dispatchEvent(makeDragEvent('drop', [makeFile('doc.txt', 10)]));
+    await new Promise<void>((r) => setTimeout(r, 0));
+    expect(onDrop).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(
+      'wrong-extension',
+      'Only .stl files are supported',
+    );
+  });
+
+  test('multi-file drop → multiple-files error, no onDrop', async () => {
+    const onDrop = vi.fn();
+    const onError = vi.fn();
+    attachDropZone(target, { onDrop, onError });
+    target.dispatchEvent(
+      makeDragEvent('drop', [
+        makeFile('a.stl', 10),
+        makeFile('b.stl', 10),
+      ]),
+    );
+    await new Promise<void>((r) => setTimeout(r, 0));
+    expect(onDrop).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(
+      'multiple-files',
+      'Drop one file at a time',
+    );
+  });
+
+  test('oversized file → file-too-large, buffer not read', async () => {
+    const onDrop = vi.fn();
+    const onError = vi.fn();
+    attachDropZone(target, { onDrop, onError });
+    const huge = makeFile('huge.stl', OPEN_STL_MAX_BYTES + 1);
+    // Spy on arrayBuffer() to prove we never allocate a 500 MB buffer.
+    const spy = vi.spyOn(huge, 'arrayBuffer');
+    target.dispatchEvent(makeDragEvent('drop', [huge]));
+    await new Promise<void>((r) => setTimeout(r, 0));
+    expect(onDrop).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith('file-too-large', 'File too large');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test('file exactly at the size cap is accepted', async () => {
+    const onDrop = vi.fn();
+    const onError = vi.fn();
+    attachDropZone(target, { onDrop, onError });
+    target.dispatchEvent(
+      makeDragEvent('drop', [makeFile('edge.stl', OPEN_STL_MAX_BYTES)]),
+    );
+    await new Promise<void>((r) => setTimeout(r, 0));
+    expect(onDrop).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test('empty drop (0 files) is a silent no-op', async () => {
+    const onDrop = vi.fn();
+    const onError = vi.fn();
+    attachDropZone(target, { onDrop, onError });
+    target.dispatchEvent(makeDragEvent('drop', []));
+    await new Promise<void>((r) => setTimeout(r, 0));
+    expect(onDrop).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test('security: does NOT consult file.path', async () => {
+    // Guard against a regression where someone reaches for `file.path`
+    // to shortcut the buffer read (would violate contextIsolation). We
+    // install a getter on `file.path` and assert it is never triggered
+    // during a successful drop flow.
+    const onDrop = vi.fn();
+    attachDropZone(target, { onDrop, onError: vi.fn() });
+    const file = makeFile('cube.stl', 84);
+    const pathSpy = vi.fn(() => '/tmp/cube.stl');
+    Object.defineProperty(file, 'path', {
+      configurable: true,
+      get: pathSpy,
+    });
+    target.dispatchEvent(makeDragEvent('drop', [file]));
+    await new Promise<void>((r) => setTimeout(r, 0));
+    expect(pathSpy).not.toHaveBeenCalled();
+    expect(onDrop).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('dropZone — lifecycle', () => {
+  test('destroy() detaches listeners + clears active class', () => {
+    const onDrop = vi.fn();
+    const onError = vi.fn();
+    const api = attachDropZone(target, { onDrop, onError });
+    const f = [makeFile('x.stl', 10)];
+    target.dispatchEvent(makeDragEvent('dragenter', f));
+    expect(target.classList.contains('dropzone--active')).toBe(true);
+
+    api.destroy();
+    expect(target.classList.contains('dropzone--active')).toBe(false);
+
+    // No further events should reach the callbacks.
+    target.dispatchEvent(makeDragEvent('drop', f));
+    expect(onDrop).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/tests/renderer/ui/errorToast.test.ts
+++ b/tests/renderer/ui/errorToast.test.ts
@@ -1,0 +1,79 @@
+// tests/renderer/ui/errorToast.test.ts
+//
+// @vitest-environment happy-dom
+//
+// Coverage for the consolidated user-visible error channel introduced in
+// issue #27. Primary scope: idempotent show/clear, auto-dismiss timer,
+// text replacement on rapid successive calls.
+//
+// Not covered here: CSS transitions (Vitest + happy-dom don't run them),
+// or the route-through from drop-zone / Open-STL — those live in the
+// E2E spec.
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  __resetForTests,
+  clear,
+  currentMessage,
+  showError,
+} from '@/renderer/ui/errorToast';
+
+beforeEach(() => {
+  __resetForTests();
+  document.body.innerHTML = '';
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('errorToast', () => {
+  test('showError mounts the overlay and sets the message', () => {
+    showError('Something broke');
+    const el = document.getElementById('app-error-toast');
+    expect(el).not.toBeNull();
+    expect(el?.textContent).toBe('Something broke');
+    expect(el?.hidden).toBe(false);
+    expect(el?.classList.contains('is-visible')).toBe(true);
+    expect(el?.getAttribute('role')).toBe('alert');
+  });
+
+  test('currentMessage reflects the active text, empty when hidden', () => {
+    expect(currentMessage()).toBe('');
+    showError('foo');
+    expect(currentMessage()).toBe('foo');
+    clear();
+    expect(currentMessage()).toBe('');
+  });
+
+  test('successive calls replace the message (no queue)', () => {
+    showError('first');
+    showError('second');
+    expect(currentMessage()).toBe('second');
+  });
+
+  test('auto-dismiss after 5 s', () => {
+    showError('gone in 5s');
+    expect(currentMessage()).toBe('gone in 5s');
+    vi.advanceTimersByTime(4999);
+    expect(currentMessage()).toBe('gone in 5s');
+    vi.advanceTimersByTime(2);
+    expect(currentMessage()).toBe('');
+  });
+
+  test('clear() cancels the pending auto-dismiss', () => {
+    showError('x');
+    clear();
+    // Advance past the would-be timeout — no throw, state still empty.
+    vi.advanceTimersByTime(10_000);
+    expect(currentMessage()).toBe('');
+  });
+
+  test('showError("") is treated as clear()', () => {
+    showError('x');
+    showError('');
+    expect(currentMessage()).toBe('');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': r('./src'),
+      '@shared': r('./shared'),
       '@fixtures': r('./tests/fixtures'),
     },
   },


### PR DESCRIPTION
Closes #27.

## Summary

- **Drop handler** (`src/renderer/ui/dropZone.ts`): attached to `#app` so drops anywhere in the window work. Validates single-file + `.stl` extension + size <= `OPEN_STL_MAX_BYTES`. Reads bytes via `File.arrayBuffer()` — never touches `file.path` or any Node fs API, so the renderer's `contextIsolation` + `sandbox` boundary is preserved. Tracks a dragenter/leave depth counter so the accent outline doesn't flicker on child boundaries.
- **Shared post-load path**: `handleOpenStl` was refactored to extract `loadMasterFromBuffer(buffer)`; drag-drop and Open-STL both call it, so the same stale-invalidation sweep (epoch bump, null silicone/resin, reset lay-flat toggle, clear generate error, flip hint) runs for both entry points.
- **Consolidated error channel** (`src/renderer/ui/errorToast.ts`): per issue #27's "consolidate if there isn't one" — a minimal singleton toast. The existing Open-STL IPC error codes now route through it too, replacing the old console-only logs.
- **i18n**: `errors.stlOnly`, `errors.singleFile`, `errors.fileTooLarge`, `errors.readFailed`. No hardcoded English in the new call sites.
- **No new IPC**. No CSP / Electron / vite.config changes. No new runtime deps.

## Acceptance criteria

- [x] Drop single `.stl` → mesh loads, volume updates, camera frames — identical to Open STL.
- [x] Drop non-STL → user-visible error ("Only .stl files are supported"); no state change.
- [x] Drop multiple files → user-visible error ("Drop one file at a time"); no state change.
- [x] Drop file > 500 MB → user-visible error ("File too large"); no state change.
- [x] Dragover visual feedback (accent outline) on `dragenter`, hides on `dragleave` / `drop`.
- [x] Renderer does NOT access `file.path` or any Node fs API — unit test asserts a getter on `file.path` is never triggered during a successful drop.
- [x] E2E Playwright spec: programmatic drop of `tests/fixtures/meshes/unit-cube.stl` → post-load state identical to dialog flow.

## Test plan

- [x] `pnpm lint` — clean.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm test` — 23 files, 241 passed (1 pre-existing skip). New coverage: 13 unit tests for dropZone validation + lifecycle + security, 6 unit tests for errorToast.
- [x] `pnpm test:e2e` (full suite, 16 tests) — all pass, including the 4 new drag-drop specs and the existing `load-stl-flow` regression path.

## Deviations

- Chose to refactor `handleOpenStl` into `loadMasterFromBuffer` rather than duplicating the post-load state resets. Keeps both entry points in lock-step on stale-invalidation semantics.
- Added `@shared` alias to `vitest.config.ts` to match the existing Vite + tsconfig aliases. All three configs now agree.

## QA

`qa-engineer` review requested. Do not merge before QA + green CI.