### PR TITLE
feat(viewer): preview silicone halves + exploded-view toggle (#47)

### DIFF
--- a/src/renderer/i18n/en.json
+++ b/src/renderer/i18n/en.json
@@ -40,6 +40,10 @@
     "reset": "Reset orientation",
     "resetHint": "Restore the mesh to its original STL orientation"
   },
+  "explodedView": {
+    "toggle": "Exploded view",
+    "toggleHint": "Show the two silicone halves moved apart so the cavity is visible"
+  },
   "generate": {
     "button": "Generate mold",
     "buttonBusy": "Generating…",

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -130,6 +130,15 @@
         color: #0b0d10;
         border-color: var(--accent);
       }
+      .exploded-view {
+        display: inline-flex;
+      }
+      .exploded-view__toggle[aria-pressed='true'],
+      .exploded-view__toggle.is-active {
+        background: var(--accent);
+        color: #0b0d10;
+        border-color: var(--accent);
+      }
       /* ---- Body layout: viewport + sidebar grid -------------------------- */
       #body {
         flex: 1 1 auto;

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -53,12 +53,17 @@ import {
   mountPlaceOnFaceToggle,
   type PlaceOnFaceToggleApi,
 } from './ui/placeOnFaceToggle';
+import {
+  mountExplodedViewToggle,
+  type ExplodedViewToggleApi,
+} from './ui/explodedViewToggle';
 
 let topbar: TopbarApi | null = null;
 let viewport: MountedViewport | null = null;
 let parametersStore: ParametersStore | null = null;
 let parameterPanel: ParameterPanelApi | null = null;
 let placeOnFace: PlaceOnFaceToggleApi | null = null;
+let explodedView: ExplodedViewToggleApi | null = null;
 let generateButton: GenerateButtonApi | null = null;
 let generateOrchestrator: GenerateOrchestratorApi | null = null;
 
@@ -101,6 +106,20 @@ function mountUi(): void {
       },
     });
 
+    // Exploded-view toggle (issue #47). Sits next to Place-on-face. Stays
+    // disabled until `generateOrchestrator` successfully installs
+    // silicone into the scene — we flip enabled=true inside the
+    // orchestrator's `onSiliconeInstalled` hook (wired in
+    // `mountParameters`). Every staleness transition also flips
+    // enabled=false (wired in `attachGenerateInvalidation` + the
+    // loadMasterFromBuffer path).
+    explodedView = mountExplodedViewToggle(center, {
+      onToggle(active) {
+        if (!viewport) return;
+        viewport.setExplodedView(active);
+      },
+    });
+
     // Mirror viewport-side state transitions (auto-exit-on-commit,
     // Escape-key exit) back into the toggle button so its pressed state
     // never drifts from the controller's truth.
@@ -121,6 +140,7 @@ function mountUi(): void {
     const hooks = w.__testHooks ?? {};
     hooks['topbar'] = topbar;
     if (placeOnFace) hooks['placeOnFace'] = placeOnFace;
+    if (explodedView) hooks['explodedView'] = explodedView;
     w.__testHooks = hooks;
   }
 }
@@ -208,6 +228,24 @@ function mountParameters(): void {
       generate: generateSiliconeShell,
       topbar: tbar,
       button: btn,
+      // Issue #47: hand the generated halves to the scene's silicone
+      // module on the happy path INSTEAD of `.delete()`-ing them. The
+      // viewport's `setSilicone` also re-frames the camera to the
+      // master+silicone union, so the user sees the full result
+      // without a manual zoom-out.
+      scene: {
+        setSilicone: (halves) => vp.setSilicone(halves),
+      },
+      onSiliconeInstalled() {
+        // Silicone is in the scene → the exploded-view toggle can be
+        // used. Start collapsed (setActive(false)) because every fresh
+        // generate resets the state — the scene module installs halves
+        // with currentFraction = 0.
+        if (explodedView) {
+          explodedView.setActive(false);
+          explodedView.setEnabled(true);
+        }
+      },
     });
   }
 
@@ -220,10 +258,25 @@ function mountParameters(): void {
   //     previously-computed volumes are stale for the new frame),
   //   - clears any lingering error message from a prior failed attempt,
   //   - bumps the shared generate-epoch counter so any in-flight
-  //     `generateSiliconeShell` promise drops its result on resolve.
+  //     `generateSiliconeShell` promise drops its result on resolve,
+  //   - tears down the silicone preview + disposes paired Manifolds
+  //     (issue #47 — silicone lifetime matches the volume-readout
+  //     lifetime, so every staleness signal clears both).
   // See `src/renderer/ui/generateInvalidation.ts` for the full semantics.
-  if (topbar && generateButton) {
-    attachGenerateInvalidation(topbar, generateButton);
+  if (topbar && generateButton && viewport) {
+    const vp = viewport;
+    attachGenerateInvalidation(topbar, generateButton, {
+      clearSilicone: () => {
+        vp.clearSilicone();
+        // Keep the exploded-view toggle's enabled state in lock-step with
+        // whether silicone is in the scene. Also force the pressed state
+        // off so a stale "exploded" flag doesn't carry over to the next
+        // generate cycle.
+        if (explodedView) {
+          explodedView.setEnabled(false);
+        }
+      },
+    });
   }
 
   if (process.env.NODE_ENV === 'test') {
@@ -265,6 +318,14 @@ async function loadMasterFromBuffer(buffer: ArrayBuffer): Promise<void> {
   // the invalidation listener covers only the "had-commit → new-STL"
   // path. Bumping here covers the first-load / no-prior-commit path too.
   bumpGenerateEpoch();
+  // Issue #47: any silicone preview attached to the PREVIOUS master is
+  // stale. Tear it down + release the cached half-Manifolds. Idempotent
+  // and safe on a first-load with no silicone installed. The
+  // `notifyMasterReset` path fires a committed-event (→ listener does
+  // the same) only when a commit was previously live; covering both
+  // paths here makes first-load-with-stale-silicone-from-prior-master
+  // safe as well.
+  viewport.clearSilicone();
   if (topbar) {
     topbar.setMasterVolume(result.volume_mm3);
     // Any previously-populated silicone + resin values are for the OLD
@@ -286,6 +347,10 @@ async function loadMasterFromBuffer(buffer: ArrayBuffer): Promise<void> {
   if (placeOnFace) {
     placeOnFace.setEnabled(true);
     placeOnFace.setActive(false);
+  }
+  // Silicone is gone → exploded-view toggle goes back to disabled + off.
+  if (explodedView) {
+    explodedView.setEnabled(false);
   }
   // Flip the Generate-block's hint from "Load an STL to begin." to
   // "Orient the part on its base...". The button stays disabled — the

--- a/src/renderer/scene/index.ts
+++ b/src/renderer/scene/index.ts
@@ -8,7 +8,10 @@
 //   │   └── origin-gizmos (Group)
 //   │       ├── GridHelper (tag: 'grid-major' + 'grid-minor' child)
 //   │       └── AxesHelper (tag: 'world-axes')
-//   ├── Master (Group, tag: 'master')   ← populated by later PRs
+//   ├── Master (Group, tag: 'master')   ← populated by `scene/master.ts`
+//   ├── Silicone (Group, tag: 'silicone')   ← populated by `scene/silicone.ts`
+//   │   ├── Mesh (tag: 'silicone-upper', translucent blue)
+//   │   └── Mesh (tag: 'silicone-lower', translucent blue)
 //   ├── Mold   (Group, tag: 'mold', visible=false)   ← populated later
 //   └── Widgets (Group, tag: 'widgets')   ← populated later
 //
@@ -56,6 +59,15 @@ export function createScene(): Scene {
   const master = new Group();
   master.userData['tag'] = 'master';
   scene.add(master);
+
+  // Silicone halves preview group (issue #47). Populated by
+  // `scene/silicone.ts` after a successful `generateSiliconeShell` run.
+  // The halves render at world origin because the generator applies the
+  // view transform internally — no group-level rotation/translation
+  // compounded here.
+  const silicone = new Group();
+  silicone.userData['tag'] = 'silicone';
+  scene.add(silicone);
 
   const mold = new Group();
   mold.userData['tag'] = 'mold';

--- a/src/renderer/scene/silicone.ts
+++ b/src/renderer/scene/silicone.ts
@@ -1,0 +1,461 @@
+// src/renderer/scene/silicone.ts
+//
+// Scene module owning the two silicone-half meshes produced by the
+// `generateSiliconeShell` generator (Phase 3d wave 1, issue #47). This
+// mirrors the `scene/master.ts` lifecycle pattern:
+//
+//   - one silicone-half pair live at a time,
+//   - `setSilicone(scene, halves)` disposes the previous pair (geometry,
+//     material, and Manifold `.delete()`) before installing the new one,
+//   - `clearSilicone(scene)` is idempotent and safe on an empty group
+//     (used by every staleness signal: commit, reset, new-STL).
+//
+// Ownership handoff:
+//
+//   The caller (`generateOrchestrator.ts` on the happy path) passes in
+//   two freshly-generated Manifolds. From the moment `setSilicone` returns,
+//   THIS MODULE owns their lifetime — the caller must NOT `.delete()` them
+//   again. Eviction happens on the next `setSilicone` call, on any
+//   `clearSilicone` call, and on viewport teardown (future hook).
+//
+// Frame alignment (the non-obvious bit):
+//
+//   `generateSiliconeShell` applies the Master group's world matrix to the
+//   master Manifold INSIDE the generator, so the half-Manifolds it returns
+//   are ALREADY in the world frame. That means we render them at world
+//   origin with no group transform — no rotation, no translation. If we
+//   composed the Master group's transform on top, we'd double-apply it and
+//   the halves would drift away from the visible master.
+//
+// Material:
+//
+//   `MeshStandardMaterial({ color: 0x4a9eff, transparent: true,
+//                           opacity: 0.35, side: DoubleSide,
+//                           depthWrite: false, roughness: 0.6,
+//                           metalness: 0.0 })`
+//
+//   `0x4a9eff` matches the CSS `--accent` token — silicone reads as
+//   "app-blue translucent". `depthWrite: false` is the standard
+//   translucent-mesh dance: it avoids self-z-fighting between a pair of
+//   overlapping translucent bodies' front and back faces. No new colour
+//   tokens introduced.
+//
+// Exploded view:
+//
+//   The parting plane is always horizontal in v1 (`[0, 1, 0]` normal;
+//   see `src/geometry/generateMold.ts` step 4). Exploded offset is ±Y:
+//     offset = max(30, 0.2 * bboxHeight_mm)
+//   Tween over 250 ms via a lightweight RAF loop owned by this module.
+//   No new tween library — vanilla `performance.now` + clamp-to-[0,1].
+//
+// Test-hook surface:
+//
+//   No module-level hooks exposed here. Consumers go through `scene` +
+//   traversal (`userData.tag === 'silicone'`) — same contract master /
+//   lay-flat use. The siblings keep the test API surface small.
+
+import {
+  Box3,
+  DoubleSide,
+  Group,
+  Mesh,
+  MeshStandardMaterial,
+  type Scene,
+} from 'three';
+import type { Manifold } from 'manifold-3d';
+
+import { manifoldToBufferGeometry } from '@/geometry/adapters';
+
+/** Tag on the silicone group created in `scene/index.ts`. */
+const SILICONE_GROUP_TAG = 'silicone';
+
+/** Per-mesh tags so tests can distinguish the two halves. */
+const SILICONE_UPPER_MESH_TAG = 'silicone-upper';
+const SILICONE_LOWER_MESH_TAG = 'silicone-lower';
+
+/**
+ * `userData` keys where we cache the Manifolds so `clearSilicone` can
+ * release them even if the Mesh nodes have been removed by some other
+ * code path. Exported so future code (a dispose hook on viewport
+ * teardown) can read the same slots.
+ */
+export const SILICONE_UPPER_MANIFOLD_KEY = 'siliconeUpperManifold';
+export const SILICONE_LOWER_MANIFOLD_KEY = 'siliconeLowerManifold';
+
+/** Default exploded-offset floor in mm (AC: `max(30, 0.2 * bboxHeight)`). */
+const EXPLODED_OFFSET_FLOOR_MM = 30;
+/** Fraction of bbox-height used for the exploded-offset ceiling. */
+const EXPLODED_OFFSET_BBOX_FRACTION = 0.2;
+/** Tween duration for exploded-view transitions. */
+const EXPLODED_TWEEN_MS = 250;
+
+/**
+ * Shape returned by `setSilicone`. `bbox` is the world-space AABB of
+ * the COMBINED halves (upper ∪ lower) computed from the Manifolds before
+ * any exploded-view offset has been applied. Callers use it to frame the
+ * camera over the master + silicone union.
+ */
+export interface SiliconeResult {
+  readonly bbox: Box3;
+  readonly upperMesh: Mesh;
+  readonly lowerMesh: Mesh;
+}
+
+/**
+ * Internal record stashed on the silicone group's `userData` so
+ * `setExplodedView` can locate the tween target + Y-resting positions
+ * without re-traversing the scene graph on every RAF tick.
+ */
+interface SiliconeState {
+  upperMesh: Mesh;
+  lowerMesh: Mesh;
+  /** Max +Y offset for the upper mesh (lower mesh uses −offsetMax). */
+  offsetMax_mm: number;
+  /** Current exploded fraction in [0, 1]: 0 = collapsed, 1 = fully apart. */
+  currentFraction: number;
+  /** Target exploded fraction; the tween walks `currentFraction` to this. */
+  targetFraction: number;
+  /** `performance.now()` at which the in-flight tween started (null = idle). */
+  tweenStart_ms: number | null;
+  /** Starting fraction at tween-start — lets mid-flight reversals tween smoothly. */
+  tweenStartFraction: number;
+  /** RAF handle for the in-flight tween (0 = none). */
+  rafId: number;
+}
+
+/** `userData` key on the silicone group where the state record lives. */
+const SILICONE_STATE_KEY = 'siliconeState';
+
+/**
+ * Locate the silicone group in `scene` by its `userData.tag`. Returns
+ * `null` if the scene skeleton is missing the group — caller treats that
+ * as a developer error.
+ */
+function findSiliconeGroup(scene: Scene): Group | null {
+  for (const child of scene.children) {
+    if (
+      child.userData['tag'] === SILICONE_GROUP_TAG &&
+      child instanceof Group
+    ) {
+      return child;
+    }
+  }
+  return null;
+}
+
+/**
+ * Read (or null-out) the state record cached on the silicone group.
+ * The record is populated inside `setSilicone` and cleared inside
+ * `clearSilicone`.
+ */
+function getState(group: Group): SiliconeState | null {
+  const s = group.userData[SILICONE_STATE_KEY] as SiliconeState | undefined;
+  return s ?? null;
+}
+function setState(group: Group, state: SiliconeState | null): void {
+  if (state === null) {
+    delete group.userData[SILICONE_STATE_KEY];
+  } else {
+    group.userData[SILICONE_STATE_KEY] = state;
+  }
+}
+
+/**
+ * Dispose a mesh's GPU resources (geometry + material) and remove it from
+ * its parent. Safe on a mesh without a parent (no-op on the removal half).
+ */
+function disposeMesh(mesh: Mesh): void {
+  mesh.geometry.dispose();
+  const mat = mesh.material;
+  if (Array.isArray(mat)) {
+    for (const m of mat) m.dispose();
+  } else {
+    mat.dispose();
+  }
+  if (mesh.parent) mesh.parent.remove(mesh);
+}
+
+/**
+ * Release a cached Manifold on the group's userData and clear the slot.
+ * Idempotent. `.delete()` releases the underlying WASM heap allocation —
+ * dropping the JS reference without calling it would leak.
+ */
+function disposeCachedManifold(group: Group, key: string): void {
+  const cached = group.userData[key] as Manifold | undefined;
+  if (cached) {
+    try {
+      cached.delete();
+    } catch (err) {
+      console.warn(`[silicone] disposing cached Manifold (${key}) threw:`, err);
+    }
+    delete group.userData[key];
+  }
+}
+
+/**
+ * Cancel any in-flight exploded-view tween. Safe to call on idle state.
+ * Used inside `setSilicone` (we fully reset on every swap) and
+ * `clearSilicone` (idempotent teardown).
+ */
+function cancelTween(state: SiliconeState): void {
+  if (state.rafId !== 0) {
+    cancelAnimationFrame(state.rafId);
+    state.rafId = 0;
+  }
+  state.tweenStart_ms = null;
+}
+
+/**
+ * Create the shared translucent silicone material. One fresh copy per
+ * mesh so each is independently disposable — sharing would complicate
+ * the per-half teardown path. At two halves × a few materials' worth of
+ * uniforms, the memory cost is negligible.
+ */
+function createSiliconeMaterial(): MeshStandardMaterial {
+  return new MeshStandardMaterial({
+    color: 0x4a9eff,
+    transparent: true,
+    opacity: 0.35,
+    side: DoubleSide,
+    depthWrite: false,
+    roughness: 0.6,
+    metalness: 0.0,
+  });
+}
+
+/**
+ * Compute the world-space AABB of the combined halves from the halves'
+ * BufferGeometries. We trust manifold-3d's `boundingBox()` but take it
+ * from the BufferGeometry post-conversion for consistency with the
+ * rendered mesh (the generator applied the view transform to the
+ * Manifold so both are in world frame).
+ */
+function unionBbox(upperMesh: Mesh, lowerMesh: Mesh): Box3 {
+  const box = new Box3();
+  upperMesh.geometry.computeBoundingBox();
+  lowerMesh.geometry.computeBoundingBox();
+  if (upperMesh.geometry.boundingBox) {
+    box.union(upperMesh.geometry.boundingBox);
+  }
+  if (lowerMesh.geometry.boundingBox) {
+    box.union(lowerMesh.geometry.boundingBox);
+  }
+  return box;
+}
+
+/**
+ * Resolve the exploded-offset distance for a given combined bbox. Applies
+ * the AC rule: `max(30 mm, 0.2 * bboxHeight)`. The bbox-height is the Y
+ * extent of the combined silicone AABB — for a horizontal parting plane
+ * the halves sit stacked along Y, so this is the natural metric.
+ */
+function resolveExplodedOffset(bbox: Box3): number {
+  const heightY = Math.max(0, bbox.max.y - bbox.min.y);
+  return Math.max(
+    EXPLODED_OFFSET_FLOOR_MM,
+    heightY * EXPLODED_OFFSET_BBOX_FRACTION,
+  );
+}
+
+/**
+ * Apply a fractional exploded offset to the half meshes. `fraction = 0`
+ * collapses both halves to y = 0 (resting); `fraction = 1` pushes the
+ * upper half to `+offsetMax` and the lower half to `−offsetMax` along Y.
+ *
+ * Writing `mesh.position.y` is the group-level-transform rule applied to
+ * the mesh itself — we never mutate the BufferGeometry vertex data. The
+ * halves share a silicone group that always stays at world origin, so
+ * the mesh's local Y offset equals the world displacement.
+ */
+function applyFraction(state: SiliconeState, fraction: number): void {
+  const clamped = Math.max(0, Math.min(1, fraction));
+  state.currentFraction = clamped;
+  state.upperMesh.position.y = clamped * state.offsetMax_mm;
+  state.lowerMesh.position.y = -clamped * state.offsetMax_mm;
+}
+
+/**
+ * Kick off (or update) an exploded-view tween toward `targetFraction`.
+ * Uses a lightweight RAF loop owned by this module — no external tween
+ * library. Reversing mid-flight is handled by snapshotting
+ * `tweenStartFraction` at the moment the new target is set.
+ *
+ * Linear easing — the tween is short (250 ms) and the motion is along a
+ * single axis, so the lack of easing is imperceptible. Keeping it linear
+ * also makes the math testable without a timing harness.
+ */
+function startTween(state: SiliconeState, targetFraction: number): void {
+  // Cancel any previous tween and re-seed from the CURRENT fraction so
+  // reversals are smooth: "mid-open" → "close" tweens from wherever the
+  // halves actually are, not from 1 (or 0).
+  cancelTween(state);
+  state.targetFraction = targetFraction;
+  state.tweenStartFraction = state.currentFraction;
+  state.tweenStart_ms = performance.now();
+
+  const step = (): void => {
+    if (state.tweenStart_ms === null) return;
+    const elapsed = performance.now() - state.tweenStart_ms;
+    const t = Math.max(0, Math.min(1, elapsed / EXPLODED_TWEEN_MS));
+    const fraction =
+      state.tweenStartFraction +
+      (state.targetFraction - state.tweenStartFraction) * t;
+    applyFraction(state, fraction);
+    if (t >= 1) {
+      state.rafId = 0;
+      state.tweenStart_ms = null;
+      return;
+    }
+    state.rafId = requestAnimationFrame(step);
+  };
+  state.rafId = requestAnimationFrame(step);
+}
+
+/**
+ * Install a freshly-generated pair of silicone half-Manifolds into the
+ * scene's silicone group. Disposes any previously-installed pair first —
+ * only one pair is live at a time, matching the `setMaster` invariant.
+ *
+ * Ownership: from the moment this function returns successfully, the
+ * scene owns both Manifolds. The caller MUST NOT `.delete()` them. The
+ * next `setSilicone` call (or `clearSilicone`) evicts them via the same
+ * cached-handle path `scene/master.ts` uses.
+ *
+ * Failure mode: if either BufferGeometry adapter throws, we dispose any
+ * partially-built state AND delete both Manifolds so the caller's
+ * lifetime assumption ("ownership transferred, don't double-free") still
+ * holds without leaking WASM memory.
+ *
+ * @throws If the scene is missing its silicone group (developer error).
+ */
+export async function setSilicone(
+  scene: Scene,
+  halves: { upper: Manifold; lower: Manifold },
+): Promise<SiliconeResult> {
+  const group = findSiliconeGroup(scene);
+  if (!group) {
+    // Ownership transfer hasn't happened yet; dispose the caller's
+    // Manifolds so the error path doesn't leak WASM heap.
+    try { halves.upper.delete(); } catch { /* already dead */ }
+    try { halves.lower.delete(); } catch { /* already dead */ }
+    throw new Error(
+      'setSilicone: scene is missing its silicone group (userData.tag === "silicone"). ' +
+        'createScene() must have run first.',
+    );
+  }
+
+  // Build display geometries for both halves FIRST, before touching the
+  // existing children. If the adapter throws on one of them, we never
+  // entered the "swap in progress" state — easy recovery.
+  let upperGeom;
+  let lowerGeom;
+  try {
+    upperGeom = await manifoldToBufferGeometry(halves.upper);
+    lowerGeom = await manifoldToBufferGeometry(halves.lower);
+  } catch (err) {
+    // Ownership transfer never completes on the error branch — dispose
+    // both Manifolds and anything we'd already built.
+    if (upperGeom) upperGeom.dispose();
+    try { halves.upper.delete(); } catch { /* already dead */ }
+    try { halves.lower.delete(); } catch { /* already dead */ }
+    throw err;
+  }
+
+  // Now swap. Tear down the previous pair (meshes + manifolds + tween)
+  // atomically before installing the new one.
+  const prev = getState(group);
+  if (prev) cancelTween(prev);
+  const existing = [...group.children];
+  for (const child of existing) {
+    if (child instanceof Mesh) disposeMesh(child);
+  }
+  disposeCachedManifold(group, SILICONE_UPPER_MANIFOLD_KEY);
+  disposeCachedManifold(group, SILICONE_LOWER_MANIFOLD_KEY);
+  setState(group, null);
+
+  // Install the new meshes. One material instance per mesh so per-half
+  // disposal is independent.
+  const upperMesh = new Mesh(upperGeom, createSiliconeMaterial());
+  upperMesh.userData['tag'] = SILICONE_UPPER_MESH_TAG;
+  const lowerMesh = new Mesh(lowerGeom, createSiliconeMaterial());
+  lowerMesh.userData['tag'] = SILICONE_LOWER_MESH_TAG;
+  group.add(upperMesh);
+  group.add(lowerMesh);
+
+  // Cache the Manifolds on the group so `clearSilicone` (and future
+  // disposal paths) can release WASM memory without needing the caller
+  // to hold onto them.
+  group.userData[SILICONE_UPPER_MANIFOLD_KEY] = halves.upper;
+  group.userData[SILICONE_LOWER_MANIFOLD_KEY] = halves.lower;
+
+  // Combined world-space bbox + exploded-offset computation.
+  const bbox = unionBbox(upperMesh, lowerMesh);
+  const offsetMax_mm = resolveExplodedOffset(bbox);
+
+  const state: SiliconeState = {
+    upperMesh,
+    lowerMesh,
+    offsetMax_mm,
+    currentFraction: 0,
+    targetFraction: 0,
+    tweenStart_ms: null,
+    tweenStartFraction: 0,
+    rafId: 0,
+  };
+  setState(group, state);
+
+  // Fresh halves render collapsed (fraction=0). Explicitly apply to pin
+  // the initial Y — positions default to zero on a fresh Mesh, but we
+  // assert via the test the invariant holds.
+  applyFraction(state, 0);
+
+  return { bbox, upperMesh, lowerMesh };
+}
+
+/**
+ * Remove both silicone halves from the scene, dispose their GPU resources,
+ * and `.delete()` the paired Manifolds. Idempotent and safe to call on a
+ * scene that has no silicone installed — every staleness signal (commit,
+ * reset, new-STL, viewport teardown) routes through this one function.
+ */
+export function clearSilicone(scene: Scene): void {
+  const group = findSiliconeGroup(scene);
+  if (!group) return;
+  const state = getState(group);
+  if (state) cancelTween(state);
+  const existing = [...group.children];
+  for (const child of existing) {
+    if (child instanceof Mesh) disposeMesh(child);
+  }
+  disposeCachedManifold(group, SILICONE_UPPER_MANIFOLD_KEY);
+  disposeCachedManifold(group, SILICONE_LOWER_MANIFOLD_KEY);
+  setState(group, null);
+}
+
+/**
+ * Toggle the exploded-view state. `true` animates the halves apart over
+ * ~250 ms; `false` collapses them back. No-op when no silicone is
+ * installed — the toggle's enabled-gate in the UI prevents that path
+ * in production, but we short-circuit here for defence-in-depth.
+ *
+ * Mid-flight toggles are supported: the tween re-seeds from the current
+ * fraction so a user who flips the toggle back before the animation
+ * completes doesn't see a snap.
+ */
+export function setExplodedView(scene: Scene, exploded: boolean): void {
+  const group = findSiliconeGroup(scene);
+  if (!group) return;
+  const state = getState(group);
+  if (!state) return;
+  startTween(state, exploded ? 1 : 0);
+}
+
+/**
+ * Whether silicone is currently installed. Used by the toolbar toggle's
+ * enable/disable wiring — `true` when there's something worth exploding.
+ */
+export function hasSilicone(scene: Scene): boolean {
+  const group = findSiliconeGroup(scene);
+  if (!group) return false;
+  return getState(group) !== null;
+}

--- a/src/renderer/scene/viewport.ts
+++ b/src/renderer/scene/viewport.ts
@@ -16,7 +16,8 @@
 //      spec. Does NOT enable test-hook exposure.
 
 import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import type { Mesh, PerspectiveCamera, Scene, WebGLRenderer } from 'three';
+import { Box3, type Mesh, type PerspectiveCamera, type Scene, type WebGLRenderer } from 'three';
+import type { Manifold } from 'manifold-3d';
 
 import { createCamera, computeAspect, frameToBox3 } from './camera';
 import { createControls } from './controls';
@@ -34,6 +35,12 @@ import {
   setMaster as sceneSetMaster,
   type MasterResult,
 } from './master';
+import {
+  clearSilicone as sceneClearSilicone,
+  setExplodedView as sceneSetExplodedView,
+  setSilicone as sceneSetSilicone,
+  type SiliconeResult,
+} from './silicone';
 
 function hasTestQueryFlag(): boolean {
   if (typeof window === 'undefined') return false;
@@ -85,6 +92,22 @@ export interface MountedViewport {
    * `document` over polling this on every frame.
    */
   isOrientationCommitted: () => boolean;
+  /**
+   * Install a freshly-generated pair of silicone halves (issue #47).
+   * Transfers ownership of the Manifolds to the scene — caller must NOT
+   * `.delete()` them after this call. After installing, re-frames the
+   * camera to the union of the master + silicone bbox so the full
+   * result is visible.
+   */
+  setSilicone: (halves: { upper: Manifold; lower: Manifold }) => Promise<SiliconeResult>;
+  /**
+   * Tear down any silicone currently in the scene and release the paired
+   * Manifolds. Idempotent. Wired to every staleness signal (commit,
+   * reset, new-STL) via the generate-invalidation listener.
+   */
+  clearSilicone: () => void;
+  /** Toggle the exploded-view animation on/off. No-op when no silicone. */
+  setExplodedView: (exploded: boolean) => void;
   /** Stop RAF, detach listeners, dispose GPU resources, remove the canvas. */
   dispose: () => void;
 }
@@ -195,6 +218,46 @@ export function mount(container: HTMLElement): MountedViewport {
     masterLoadedResolve = resolve;
   });
 
+  /**
+   * Install a fresh pair of silicone half-Manifolds into the scene. After
+   * the scene-side adapter finishes, re-frame the camera to the union of
+   * the master group's bbox and the silicone bbox — so the user sees the
+   * whole result without a manual zoom-out (issue #47 AC).
+   *
+   * Ownership: transfers both Manifolds to the scene module. The caller
+   * (orchestrator happy-path) must NOT `.delete()` them after this
+   * resolves. On a throw, `scene/silicone.ts::setSilicone` disposes both
+   * halves before re-throwing, so the error branch preserves the
+   * lifetime contract without a second dispose here.
+   */
+  const setSilicone = async (
+    halves: { upper: Manifold; lower: Manifold },
+  ): Promise<SiliconeResult> => {
+    const installed = await sceneSetSilicone(scene, halves);
+
+    // Union the silicone bbox with the master group's world-space bbox.
+    // `Box3.setFromObject(masterGroup)` is fine here because the master
+    // group's world matrix is maintained current by every transform path
+    // (setMaster, lay-flat commit, reset) — no stale matrix risk.
+    const masterGroup = scene.children.find(
+      (c) => c.userData['tag'] === 'master',
+    );
+    const union = installed.bbox.clone();
+    if (masterGroup) {
+      const masterBbox = new Box3().setFromObject(masterGroup);
+      if (!masterBbox.isEmpty()) union.union(masterBbox);
+    }
+
+    // Defence-in-depth: only frame if the union is non-empty. The
+    // silicone bbox is non-empty by construction (two halves always have
+    // vertices), but a fully-degenerate scene shouldn't crash the framer.
+    if (!union.isEmpty()) {
+      frameToBox3(camera, controls, union);
+    }
+
+    return installed;
+  };
+
   const setMaster = async (buffer: ArrayBuffer): Promise<MasterResult> => {
     // Exit any active lay-flat session before swapping the master — the old
     // mesh (and its BVH) is about to be disposed, and stale cursor listeners
@@ -264,6 +327,9 @@ export function mount(container: HTMLElement): MountedViewport {
     // automatically when the viewport's JS state is dropped. Idempotent and
     // safe on a scene that never loaded a master.
     sceneDisposeMaster(scene);
+    // Mirror for silicone: `clearSilicone` releases the cached half-
+    // Manifolds + GPU resources. Idempotent on an empty scene.
+    sceneClearSilicone(scene);
     controls.dispose();
     renderer.dispose();
     if (canvas.parentElement === container) {
@@ -283,6 +349,9 @@ export function mount(container: HTMLElement): MountedViewport {
     isFacePickingActive: () => layFlat.isActive(),
     resetOrientation: () => layFlat.reset(),
     isOrientationCommitted: () => layFlat.isCommitted(),
+    setSilicone,
+    clearSilicone: () => sceneClearSilicone(scene),
+    setExplodedView: (exploded: boolean) => sceneSetExplodedView(scene, exploded),
     dispose,
   };
 

--- a/src/renderer/ui/explodedViewToggle.ts
+++ b/src/renderer/ui/explodedViewToggle.ts
@@ -1,0 +1,129 @@
+// src/renderer/ui/explodedViewToggle.ts
+//
+// Toolbar toggle that animates the silicone halves apart along the
+// parting-plane normal (always ±Y in v1). Sits in the topbar center slot
+// next to the Place-on-face + Reset-orientation buttons — same aria-
+// pressed convention, same disable-until-usable pattern.
+//
+// State transitions (issue #47):
+//
+//   silicone absent      → disabled, off.
+//   silicone added       → enabled,  off  (collapsed).
+//   user toggles on      → enabled,  on   (animate offset 0 → max).
+//   user toggles off     → enabled,  off  (animate offset max → 0).
+//   silicone cleared     → disabled, off  (regardless of prior state).
+//
+// The animation lives inside `scene/silicone.ts` — this module only
+// drives the boolean. Aria-pressed and `.is-active` mirror the internal
+// state; same style rule the place-on-face toggle uses (reused the
+// existing `.place-on-face__toggle` CSS via a shared mold for the
+// accent-on-pressed look; we namespace under `.exploded-view` below
+// so the two toggles stay independently targetable).
+//
+// i18n keys: `explodedView.toggle` + `explodedView.toggleHint`.
+
+import { t } from '../i18n';
+
+/** Imperative API for the mounted toggle. */
+export interface ExplodedViewToggleApi {
+  /** Programmatically flip state. Mirrors a user click (fires callback). */
+  setActive(active: boolean): void;
+  /** Enable or disable the button (e.g. when silicone is/isn't in scene). */
+  setEnabled(enabled: boolean): void;
+  /** Read the visible active state. */
+  isActive(): boolean;
+  /** Remove from DOM + detach listeners. */
+  destroy(): void;
+}
+
+/** Callback surface. `onToggle(active)` fires on every user flip. */
+export interface ExplodedViewToggleHandlers {
+  /** User flipped the toggle. Implementation wires to scene.setExplodedView. */
+  onToggle(active: boolean): void;
+}
+
+/**
+ * Mount the Exploded-view toggle button into `host`. Button starts
+ * disabled (no silicone yet); caller flips enabled via `setEnabled(true)`
+ * after a successful Generate, and back to false on every staleness
+ * transition (commit, reset, new-STL).
+ *
+ * When flipping from enabled=true to enabled=false the active flag is
+ * force-reset to `false`: "silicone cleared → toggle goes back to
+ * disabled + off, regardless of prior state" (issue #47 AC). The
+ * caller's wire to `scene.setExplodedView` doesn't need to fire — the
+ * scene module's `clearSilicone` already tears down the halves.
+ */
+export function mountExplodedViewToggle(
+  host: HTMLElement,
+  handlers: ExplodedViewToggleHandlers,
+): ExplodedViewToggleApi {
+  const root = document.createElement('div');
+  root.className = 'exploded-view';
+  root.dataset['testid'] = 'exploded-view';
+
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'exploded-view__toggle';
+  btn.dataset['testid'] = 'exploded-view-toggle';
+  btn.textContent = t('explodedView.toggle');
+  btn.title = t('explodedView.toggleHint');
+  btn.setAttribute('aria-pressed', 'false');
+  btn.disabled = true;
+
+  root.appendChild(btn);
+  host.appendChild(root);
+
+  let active = false;
+  let enabled = false;
+
+  function renderActive(): void {
+    btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+    btn.classList.toggle('is-active', active);
+  }
+
+  function renderEnabled(): void {
+    btn.disabled = !enabled;
+  }
+
+  function onClick(): void {
+    if (!enabled) return;
+    active = !active;
+    renderActive();
+    handlers.onToggle(active);
+  }
+  btn.addEventListener('click', onClick);
+
+  renderActive();
+  renderEnabled();
+
+  return {
+    setActive(next: boolean): void {
+      if (active === next) return;
+      active = next;
+      renderActive();
+      // `setActive` is a programmatic reflection of scene state — no
+      // callback. Symmetric with placeOnFaceToggle.setActive.
+    },
+    setEnabled(next: boolean): void {
+      if (enabled === next) return;
+      enabled = next;
+      renderEnabled();
+      // Disable must also collapse the toggle back to off — silicone is
+      // gone, the visual state must reflect that. The scene-side
+      // `clearSilicone` has already removed the halves, so no callback
+      // is needed; we just update local state.
+      if (!enabled && active) {
+        active = false;
+        renderActive();
+      }
+    },
+    isActive(): boolean {
+      return active;
+    },
+    destroy(): void {
+      btn.removeEventListener('click', onClick);
+      root.remove();
+    },
+  };
+}

--- a/src/renderer/ui/generateInvalidation.ts
+++ b/src/renderer/ui/generateInvalidation.ts
@@ -45,9 +45,10 @@ export type InvalidationGenerateButton = Pick<
 >;
 
 /**
- * Options for `attachGenerateInvalidation`. The `bumpEpoch` hook is
- * injectable so tests can observe the bump directly; in production it
- * defaults to the shared module-level counter in `generateEpoch.ts`.
+ * Options for `attachGenerateInvalidation`. The `bumpEpoch` + `clearSilicone`
+ * hooks are injectable so tests can observe them directly; in production
+ * `bumpEpoch` defaults to the shared module-level counter and `clearSilicone`
+ * is supplied by `main.ts` from the silicone scene module.
  */
 export interface GenerateInvalidationOptions {
   /**
@@ -55,6 +56,19 @@ export interface GenerateInvalidationOptions {
    * Defaults to `bumpGenerateEpoch` — override only in tests.
    */
   bumpEpoch?: () => number;
+  /**
+   * Tear down any silicone meshes currently in the scene and `.delete()`
+   * their paired Manifolds. Optional because pre-#47 call sites (and most
+   * unit tests) don't need it — in production `main.ts` passes the real
+   * `clearSilicone(scene)` binding from `scene/silicone.ts`.
+   *
+   * Called AFTER the epoch bump + volume-null so the silicone group is
+   * torn down in the same synchronous tick as the topbar reset. A
+   * resolving in-flight generation's `setSilicone` call sees the stale
+   * epoch and drops its halves via the orchestrator's staleness guard,
+   * so we never race the stale-drop against this clear.
+   */
+  clearSilicone?: () => void;
 }
 
 /**
@@ -65,7 +79,10 @@ export interface GenerateInvalidationOptions {
  *   - clears any pending error on the button,
  *   - bumps the shared generate-epoch counter so any in-flight
  *     `generateSiliconeShell` promise resolves into a stale-branch and
- *     drops its result (see `generateEpoch.ts` for the full rationale).
+ *     drops its result (see `generateEpoch.ts` for the full rationale),
+ *   - if `options.clearSilicone` is supplied, tears down any silicone
+ *     meshes currently in the scene (issue #47 — silicone preview
+ *     lifetime must match the topbar volumes' lifetime).
  *
  * Returns an unsubscribe function so tests (and future app teardown) can
  * detach the listener cleanly.
@@ -76,6 +93,7 @@ export function attachGenerateInvalidation(
   options: GenerateInvalidationOptions = {},
 ): () => void {
   const bump = options.bumpEpoch ?? bumpGenerateEpoch;
+  const clearSilicone = options.clearSilicone;
   const handler = (ev: Event): void => {
     const detail = (ev as CustomEvent<boolean>).detail;
     if (typeof detail !== 'boolean') return;
@@ -89,6 +107,7 @@ export function attachGenerateInvalidation(
     topbar.setSiliconeVolume(null);
     topbar.setResinVolume(null);
     generateButton.setError(null);
+    if (clearSilicone) clearSilicone();
   };
   document.addEventListener(LAY_FLAT_COMMITTED_EVENT, handler);
   return () => {

--- a/src/renderer/ui/generateOrchestrator.ts
+++ b/src/renderer/ui/generateOrchestrator.ts
@@ -37,6 +37,26 @@
 // Symmetrically on the error branch: a stale error is swallowed rather
 // than shown to the user, since an invalidation means they've already moved
 // on.
+//
+// Manifold ownership (issue #47)
+// ------------------------------
+//
+// The half-Manifolds in `SiliconeShellResult` are generator-owned until
+// the orchestrator decides what to do with them:
+//
+//   - Happy path + `scene` supplied:  ownership HANDS OFF to the scene
+//     sink via `scene.setSilicone({upper, lower})`. The orchestrator must
+//     NOT `.delete()` them afterwards — the sink does so on its next
+//     replacement / clear cycle.
+//   - Happy path + no `scene`:  fall back to the original behaviour of
+//     `.delete()`-ing here. Kept so the pre-#47 orchestrator tests (and
+//     any callers that only want volumes) still work.
+//   - Stale-drop path:  halves NEVER reached the scene → orchestrator is
+//     still the owner → `.delete()` both before returning.
+//   - Error path (generate rejected):  halves never existed (the Promise
+//     rejected before producing them) → nothing to delete.
+//   - scene.setSilicone rejects:  the scene sink is contracted to have
+//     disposed both halves on its error branch before re-throwing.
 
 import type { Manifold } from 'manifold-3d';
 import type { Matrix4 } from 'three';
@@ -55,6 +75,21 @@ export interface OrchestratorTopbar {
 export interface OrchestratorButton {
   setBusy(busy: boolean): void;
   setError(reason: string | null): void;
+}
+
+/**
+ * Minimal scene-sink surface the orchestrator hands the half-Manifolds
+ * to on the happy path. Kept as a shaped interface (rather than a direct
+ * import of the scene module) so tests can inject a lightweight mock and
+ * assert the hand-off without needing a real WebGL context.
+ *
+ * Contract: from the moment `setSilicone` resolves, the sink owns the
+ * Manifolds' lifetimes. The orchestrator MUST NOT `.delete()` them on
+ * the happy path. The stale-drop / error paths predate this ownership
+ * transfer — they still `.delete()`.
+ */
+export interface OrchestratorSceneSink {
+  setSilicone(halves: { upper: Manifold; lower: Manifold }): Promise<unknown>;
 }
 
 /** Dependencies injected into the orchestrator factory. */
@@ -87,6 +122,24 @@ export interface GenerateOrchestratorDeps {
   topbar: OrchestratorTopbar;
   /** The Generate-mold button's busy/error surface. */
   button: OrchestratorButton;
+  /**
+   * Optional scene sink (issue #47). When provided, the orchestrator
+   * hands the freshly-generated half-Manifolds to `scene.setSilicone`
+   * on the happy path INSTEAD of `.delete()`-ing them. Ownership
+   * transfers to the sink; the orchestrator's finally-block does NOT
+   * double-free. Legacy call sites (and the orchestrator's existing
+   * unit tests that predate the preview scene) can omit this — the
+   * halves fall back to being disposed here, which preserves the
+   * original "volume compute only" behaviour.
+   */
+  scene?: OrchestratorSceneSink;
+  /**
+   * Optional post-setSilicone hook for camera re-framing (issue #47).
+   * Called with the result of `scene.setSilicone` when both scene + hook
+   * are supplied and the run is still current. Only invoked on the
+   * happy, non-stale path so a superseded run can't jerk the camera.
+   */
+  onSiliconeInstalled?: (result: unknown) => void;
   /**
    * Optional epoch hooks — default to the shared module-level counter.
    * Tests override to assert bump sequences or observe the stale-path.
@@ -141,6 +194,8 @@ export function createGenerateOrchestrator(
     generate,
     topbar,
     button,
+    scene,
+    onSiliconeInstalled,
     bumpEpoch = bumpGenerateEpoch,
     getEpoch = getGenerateEpoch,
     logger = console,
@@ -184,8 +239,11 @@ export function createGenerateOrchestrator(
         const result = await generate(master, parameters, viewTransform);
 
         if (epoch !== getEpoch()) {
-          // An invalidation (commit, reset, new STL) or a later click
-          // bumped the epoch while we were awaiting — drop the result.
+          // Staleness drop: an invalidation (commit, reset, new STL) or a
+          // later click bumped the epoch while we were awaiting. The halves
+          // NEVER reached the scene, so the orchestrator is still the
+          // owner — release them here. (Issue #47 kept this branch's
+          // `.delete()` unchanged; only the happy-path hand-off moved.)
           result.siliconeUpperHalf.delete();
           result.siliconeLowerHalf.delete();
           return;
@@ -194,11 +252,45 @@ export function createGenerateOrchestrator(
         topbar.setSiliconeVolume(result.siliconeVolume_mm3);
         topbar.setResinVolume(result.resinVolume_mm3);
 
-        // v1 doesn't render or export the halves here — they were for
-        // volume compute only. Release the WASM memory now. Phase 3d
-        // will keep them alive for the preview renderer.
-        result.siliconeUpperHalf.delete();
-        result.siliconeLowerHalf.delete();
+        if (scene) {
+          // Happy path (issue #47): hand ownership of BOTH half-Manifolds
+          // to the scene sink. `scene.setSilicone` is responsible for
+          // `.delete()`-ing them on its next replacement / clear cycle —
+          // the orchestrator must NOT touch them again or we'd double-
+          // free. If `setSilicone` throws (geometry adapter failure),
+          // its implementation is responsible for disposing both
+          // Manifolds before re-throwing so the lifetime contract holds.
+          try {
+            const installed = await scene.setSilicone({
+              upper: result.siliconeUpperHalf,
+              lower: result.siliconeLowerHalf,
+            });
+            // Re-check staleness after the async setSilicone resolved —
+            // an invalidation that fires between the volume push and the
+            // scene install will have cleared the silicone group in its
+            // own tick, but `setSilicone` is idempotent and the next
+            // `clearSilicone` from the listener will catch it. The
+            // camera re-frame, however, must NOT fire on a stale run:
+            // guard with the epoch.
+            if (epoch === getEpoch() && onSiliconeInstalled) {
+              onSiliconeInstalled(installed);
+            }
+          } catch (err) {
+            // setSilicone is contracted to dispose the Manifolds on
+            // failure. We still have to surface the error — route
+            // through the button's error channel so the user sees it.
+            const message =
+              err instanceof Error ? err.message : String(err);
+            logger.error('[generate] setSilicone failed:', err);
+            button.setError(message);
+          }
+        } else {
+          // No scene sink wired (legacy call sites, some tests) — fall
+          // back to the pre-#47 behaviour of disposing the halves here
+          // for volume-compute-only mode.
+          result.siliconeUpperHalf.delete();
+          result.siliconeLowerHalf.delete();
+        }
       } catch (err) {
         // Stale rejection → user already moved on; no point alarming
         // them with an error from a superseded run.

--- a/tests/e2e/silicone-preview.spec.ts
+++ b/tests/e2e/silicone-preview.spec.ts
@@ -1,0 +1,306 @@
+// tests/e2e/silicone-preview.spec.ts
+//
+// End-to-end for issue #47: silicone preview + exploded-view toggle.
+//
+// Flow:
+//   1. Launch app, stub the Open dialog to return the mini-figurine.
+//   2. Open STL → master loads; exploded-view toggle starts disabled.
+//   3. Commit a face (camera-down-click same as `generate-wire-up.spec.ts`).
+//   4. Click Generate → wait for volumes to populate.
+//   5. Assert two silicone meshes are live in the scene (via scene.traverse).
+//   6. Assert the exploded-view toggle is enabled + not-pressed.
+//   7. Click the exploded-view toggle.
+//   8. Wait 300 ms (past the 250 ms tween) — assert upper mesh world-Y > +20.
+//   9. Click again → halves collapse back to y ≈ 0.
+//  10. Commit a different face → silicone meshes disappear + toggle disables.
+//
+// Generator budget on the mini-figurine is ~2-3 s; we set the wait ceilings
+// to 15 s for CI headroom.
+
+import { expect, test, type Page } from '@playwright/test';
+import { resolve } from 'node:path';
+import { launchApp } from './fixtures/app';
+
+const MINI_FIGURINE_PATH = resolve(
+  __dirname,
+  '..',
+  'fixtures',
+  'meshes',
+  'mini-figurine.stl',
+);
+
+/**
+ * Commit the top face by swinging the camera straight down at the
+ * figurine so a canvas-centre click hits its top surface. Same
+ * technique `generate-gate.spec.ts` / `generate-wire-up.spec.ts` use.
+ */
+async function commitTopFace(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    type ViewportHooks = {
+      viewport?: {
+        camera: {
+          position: { set: (x: number, y: number, z: number) => void };
+          up: { set: (x: number, y: number, z: number) => void };
+          lookAt: (x: number, y: number, z: number) => void;
+          updateMatrixWorld: () => void;
+          updateProjectionMatrix: () => void;
+        };
+        enableFacePicking: () => void;
+      };
+    };
+    const hooks = (window as unknown as { __testHooks?: ViewportHooks })
+      .__testHooks;
+    const vp = hooks?.viewport;
+    if (!vp) throw new Error('viewport hook missing');
+    vp.camera.position.set(0, 250, 0);
+    vp.camera.up.set(0, 0, -1);
+    vp.camera.lookAt(0, 35, 0);
+    vp.camera.updateMatrixWorld();
+    vp.camera.updateProjectionMatrix();
+    vp.enableFacePicking();
+  });
+  const canvasBox = await page.locator('#viewport canvas').boundingBox();
+  if (!canvasBox) throw new Error('canvas missing');
+  const cx = canvasBox.x + canvasBox.width / 2;
+  const cy = canvasBox.y + canvasBox.height / 2;
+  await page.mouse.move(cx, cy);
+  await page.mouse.click(cx, cy);
+  await page.waitForFunction(
+    () => {
+      type ViewportHooks = {
+        viewport?: {
+          isFacePickingActive: () => boolean;
+          isOrientationCommitted: () => boolean;
+        };
+      };
+      const hooks = (window as unknown as { __testHooks?: ViewportHooks })
+        .__testHooks;
+      return (
+        hooks?.viewport?.isFacePickingActive() === false &&
+        hooks?.viewport?.isOrientationCommitted() === true
+      );
+    },
+    undefined,
+    { timeout: 5_000 },
+  );
+}
+
+/**
+ * Commit a SIDE face — swing camera around the X axis so a canvas-centre
+ * raycast hits the side of the mini-figurine. Same helper shape as
+ * `generate-wire-up.spec.ts`.
+ */
+async function commitSideFace(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    type ViewportHooks = {
+      viewport?: {
+        resetOrientation: () => void;
+        camera: {
+          position: { set: (x: number, y: number, z: number) => void };
+          up: { set: (x: number, y: number, z: number) => void };
+          lookAt: (x: number, y: number, z: number) => void;
+          updateMatrixWorld: () => void;
+          updateProjectionMatrix: () => void;
+        };
+        enableFacePicking: () => void;
+      };
+    };
+    const hooks = (window as unknown as { __testHooks?: ViewportHooks })
+      .__testHooks;
+    const vp = hooks?.viewport;
+    if (!vp) throw new Error('viewport hook missing');
+    vp.resetOrientation();
+    vp.camera.position.set(250, 35, 0);
+    vp.camera.up.set(0, 1, 0);
+    vp.camera.lookAt(0, 35, 0);
+    vp.camera.updateMatrixWorld();
+    vp.camera.updateProjectionMatrix();
+    vp.enableFacePicking();
+  });
+  const canvasBox = await page.locator('#viewport canvas').boundingBox();
+  if (!canvasBox) throw new Error('canvas missing');
+  const cx = canvasBox.x + canvasBox.width / 2;
+  const cy = canvasBox.y + canvasBox.height / 2;
+  await page.mouse.move(cx, cy);
+  await page.mouse.click(cx, cy);
+  await page.waitForFunction(
+    () => {
+      type ViewportHooks = {
+        viewport?: { isOrientationCommitted: () => boolean };
+      };
+      const hooks = (window as unknown as { __testHooks?: ViewportHooks })
+        .__testHooks;
+      return hooks?.viewport?.isOrientationCommitted() === true;
+    },
+    undefined,
+    { timeout: 5_000 },
+  );
+}
+
+/**
+ * Count silicone meshes currently in the scene by walking from the
+ * scene-root test-hook and checking `userData.tag`. Returns the raw
+ * count so the caller can assert exactly-two.
+ */
+async function countSiliconeMeshes(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    type SceneHook = {
+      scene?: {
+        traverse: (cb: (obj: { userData?: Record<string, unknown> }) => void) => void;
+      };
+    };
+    const hooks = (window as unknown as { __testHooks?: SceneHook })
+      .__testHooks;
+    if (!hooks?.scene) throw new Error('scene hook missing');
+    let count = 0;
+    hooks.scene.traverse((obj) => {
+      const tag = obj.userData?.['tag'];
+      if (tag === 'silicone-upper' || tag === 'silicone-lower') count += 1;
+    });
+    return count;
+  });
+}
+
+/**
+ * Read the world-space Y position of the upper silicone mesh. Used to
+ * detect the exploded-view animation has landed at its +offset target.
+ */
+async function readUpperMeshWorldY(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    type Obj = {
+      userData?: Record<string, unknown>;
+      getWorldPosition?: (v: { y: number }) => { y: number };
+      position?: { y: number };
+    };
+    type SceneHook = {
+      scene?: { traverse: (cb: (obj: Obj) => void) => void };
+    };
+    const hooks = (window as unknown as { __testHooks?: SceneHook })
+      .__testHooks;
+    if (!hooks?.scene) throw new Error('scene hook missing');
+    let worldY = Number.NaN;
+    hooks.scene.traverse((obj) => {
+      if (obj.userData?.['tag'] === 'silicone-upper') {
+        // `getWorldPosition` walks the parent chain — silicone group is
+        // at identity, so world Y === mesh.position.y. We use
+        // `getWorldPosition` anyway so a future group transform would
+        // still produce the right reading.
+        if (typeof obj.getWorldPosition === 'function') {
+          const p = obj.getWorldPosition({ y: 0 });
+          worldY = p.y;
+        } else if (obj.position) {
+          worldY = obj.position.y;
+        }
+      }
+    });
+    return worldY;
+  });
+}
+
+test('silicone preview: generate → two meshes live → exploded view tweens halves apart', async () => {
+  const app = await launchApp();
+  try {
+    const page = await app.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
+
+    // Stub the dialog with the mini-figurine fixture.
+    await app.evaluate((_electron, fixturePath) => {
+      (
+        globalThis as unknown as {
+          __testDialogStub: {
+            showOpenDialog: () => Promise<{
+              canceled: boolean;
+              filePaths: string[];
+            }>;
+          };
+        }
+      ).__testDialogStub = {
+        showOpenDialog: () =>
+          Promise.resolve({ canceled: false, filePaths: [fixturePath] }),
+      };
+    }, MINI_FIGURINE_PATH);
+
+    const openBtn = page.locator('[data-testid="open-stl-btn"]');
+    await expect(openBtn).toBeVisible();
+    await expect(openBtn).toBeEnabled();
+
+    // Exploded-view toggle exists and starts disabled (no silicone yet).
+    const explodedToggle = page.locator('[data-testid="exploded-view-toggle"]');
+    await expect(explodedToggle).toBeVisible();
+    await expect(explodedToggle).toBeDisabled();
+
+    // Snapshot masterLoaded → open → await.
+    await page.evaluate(() => {
+      const hooks = (
+        window as unknown as { __testHooks?: { masterLoaded?: Promise<void> } }
+      ).__testHooks;
+      if (!hooks?.masterLoaded) throw new Error('masterLoaded hook missing');
+      (
+        globalThis as unknown as { __pendingMasterLoaded: Promise<void> }
+      ).__pendingMasterLoaded = hooks.masterLoaded;
+    });
+    await openBtn.click();
+    await page.evaluate(
+      () =>
+        (
+          globalThis as unknown as { __pendingMasterLoaded: Promise<void> }
+        ).__pendingMasterLoaded,
+    );
+
+    // Commit a face → Generate enables.
+    await commitTopFace(page);
+    await expect(page.locator('[data-testid="generate-btn"]')).toBeEnabled();
+
+    // Toggle still disabled — silicone doesn't exist yet.
+    await expect(explodedToggle).toBeDisabled();
+
+    // Click Generate. Wait for the button to flip back to the ready label
+    // (generator finished) — this is ≤ 15 s per the wire-up spec.
+    await page.locator('[data-testid="generate-btn"]').click();
+    await expect(page.locator('[data-testid="generate-btn"]'))
+      .toHaveText('Generate mold', { timeout: 15_000 });
+    await expect(page.locator('[data-testid="generate-btn"]')).toBeEnabled();
+
+    // Volumes populated (sanity — proves the orchestrator ran to completion).
+    await expect(page.locator('[data-testid="silicone-volume-value"]'))
+      .not.toHaveText('Click Generate', { timeout: 5_000 });
+
+    // Two silicone meshes live in the scene.
+    expect(await countSiliconeMeshes(page)).toBe(2);
+
+    // Toggle now enabled + not-pressed.
+    await expect(explodedToggle).toBeEnabled();
+    await expect(explodedToggle).toHaveAttribute('aria-pressed', 'false');
+
+    // Collapsed state: both halves at y ≈ 0.
+    expect(await readUpperMeshWorldY(page)).toBeCloseTo(0, 3);
+
+    // Click the toggle. Wait 300 ms so the 250 ms tween lands.
+    await explodedToggle.click();
+    await expect(explodedToggle).toHaveAttribute('aria-pressed', 'true');
+    await page.waitForTimeout(300);
+
+    // Upper mesh pushed up along +Y by the exploded offset.
+    // Offset = max(30, 0.2 * bboxHeight). For the mini-figurine the
+    // bbox height is ~70 mm → 0.2 * 70 = 14, floor = 30 → offset = 30.
+    // We assert > 20 mm to have tolerance for CI timing jitter.
+    const explodedY = await readUpperMeshWorldY(page);
+    expect(explodedY).toBeGreaterThan(20);
+
+    // Click again → collapse back to 0.
+    await explodedToggle.click();
+    await expect(explodedToggle).toHaveAttribute('aria-pressed', 'false');
+    await page.waitForTimeout(300);
+    const collapsedY = await readUpperMeshWorldY(page);
+    expect(collapsedY).toBeCloseTo(0, 2);
+
+    // Stale-invalidation: commit a different face → silicone meshes
+    // disappear AND toggle returns to disabled + not-pressed.
+    await commitSideFace(page);
+    expect(await countSiliconeMeshes(page)).toBe(0);
+    await expect(explodedToggle).toBeDisabled();
+    await expect(explodedToggle).toHaveAttribute('aria-pressed', 'false');
+  } finally {
+    await app.close();
+  }
+});

--- a/tests/e2e/silicone-preview.spec.ts
+++ b/tests/e2e/silicone-preview.spec.ts
@@ -169,8 +169,8 @@ async function readUpperMeshWorldY(page: Page): Promise<number> {
   return page.evaluate(() => {
     type Obj = {
       userData?: Record<string, unknown>;
-      getWorldPosition?: (v: { y: number }) => { y: number };
-      position?: { y: number };
+      matrixWorld?: { elements: ArrayLike<number> };
+      updateWorldMatrix?: (updateParents: boolean, updateChildren: boolean) => void;
     };
     type SceneHook = {
       scene?: { traverse: (cb: (obj: Obj) => void) => void };
@@ -181,15 +181,16 @@ async function readUpperMeshWorldY(page: Page): Promise<number> {
     let worldY = Number.NaN;
     hooks.scene.traverse((obj) => {
       if (obj.userData?.['tag'] === 'silicone-upper') {
-        // `getWorldPosition` walks the parent chain — silicone group is
-        // at identity, so world Y === mesh.position.y. We use
-        // `getWorldPosition` anyway so a future group transform would
-        // still produce the right reading.
-        if (typeof obj.getWorldPosition === 'function') {
-          const p = obj.getWorldPosition({ y: 0 });
-          worldY = p.y;
-        } else if (obj.position) {
-          worldY = obj.position.y;
+        // Read world Y directly from the 4x4 matrixWorld — element[13]
+        // is the translation.y. We can't use `getWorldPosition(v)` here
+        // because it mutates `v` via `setFromMatrixPosition`, which is
+        // a THREE.Vector3 prototype method; a plain `{y:0}` object
+        // doesn't have it and the call throws. Reading the matrix
+        // directly is equivalent AND works regardless of any future
+        // parent-group transform (mW folds the ancestor chain in).
+        if (obj.updateWorldMatrix) obj.updateWorldMatrix(true, false);
+        if (obj.matrixWorld) {
+          worldY = obj.matrixWorld.elements[13]!;
         }
       }
     });

--- a/tests/renderer/scene/silicone.test.ts
+++ b/tests/renderer/scene/silicone.test.ts
@@ -1,0 +1,445 @@
+// tests/renderer/scene/silicone.test.ts
+//
+// Unit tests for the silicone-preview scene module (`src/renderer/scene/
+// silicone.ts`, issue #47). Pins:
+//
+//   1. `setSilicone` places two Mesh children under the silicone group,
+//      each with the expected material properties (color, transparent,
+//      opacity, DoubleSide, depthWrite=false).
+//   2. `setSilicone` replaces a previous pair atomically — old meshes
+//      disposed, old Manifolds `.delete()`'d, new pair installed.
+//   3. `setSilicone` carries the halves at world origin (no inherited
+//      group transform — the generator bakes the viewport transform
+//      into the Manifolds, so double-applying would mis-align them).
+//   4. A "Generate × 3" sequence never accumulates meshes or Manifold
+//      handles: at every step exactly two meshes + two cached Manifolds.
+//   5. `clearSilicone` removes both meshes, disposes GPU resources, and
+//      calls `.delete()` on both cached Manifolds.
+//   6. `setExplodedView(true)` moves `upperMesh.y` toward `+offset` and
+//      `lowerMesh.y` toward `-offset`; `setExplodedView(false)` returns
+//      both to y=0. Offset = max(30, 0.2 * bboxHeight_mm).
+//   7. `setSilicone` returns a bbox that is the union of the two halves
+//      (consumed by camera re-frame logic).
+//
+// We don't run a real `generateSiliconeShell` — that requires the WASM
+// kernel + takes ~1-3 s per fixture. Instead we build small Manifolds
+// directly via `manifold-3d`'s JS API (unit cubes translated into
+// upper/lower half-spaces) and hand them to `setSilicone`. This
+// exercises the full adapter + scene-graph path deterministically in
+// < 100 ms.
+
+import { DoubleSide, MeshStandardMaterial, type Group, type Mesh } from 'three';
+import type { Manifold, ManifoldToplevel } from 'manifold-3d';
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { createScene } from '@/renderer/scene/index';
+import { initManifold } from '@/geometry/initManifold';
+import {
+  SILICONE_UPPER_MANIFOLD_KEY,
+  SILICONE_LOWER_MANIFOLD_KEY,
+  clearSilicone,
+  hasSilicone,
+  setExplodedView,
+  setSilicone,
+} from '@/renderer/scene/silicone';
+
+let toplevel: ManifoldToplevel;
+
+beforeAll(async () => {
+  toplevel = await initManifold();
+});
+
+/**
+ * Locate the silicone group in a freshly-built scene. Throws on
+ * mis-wired skeleton (which would be a regression in `scene/index.ts`).
+ */
+function getSiliconeGroup(scene: ReturnType<typeof createScene>): Group {
+  const grp = scene.children.find(
+    (c) => c.userData['tag'] === 'silicone',
+  ) as Group | undefined;
+  if (!grp) throw new Error('silicone group missing from scene skeleton');
+  return grp;
+}
+
+/**
+ * Build a pair of half-Manifolds: a 20×10×20 upper box (Y>0) and a
+ * 20×10×20 lower box (Y<0). They form a plausible "silicone halves"
+ * shape with a combined bbox height of 20 mm — so the exploded offset
+ * math kicks into the FLOOR branch (max(30, 0.2 * 20) = 30).
+ */
+function makeHalves(): { upper: Manifold; lower: Manifold } {
+  // `Manifold.cube([x,y,z], true)` centers at origin; translate up/down.
+  const upper = toplevel.Manifold.cube([20, 10, 20], true).translate([0, 5, 0]);
+  const lower = toplevel.Manifold.cube([20, 10, 20], true).translate([0, -5, 0]);
+  return { upper, lower };
+}
+
+/**
+ * Build a tall pair — 40 mm upper + 40 mm lower → combined height 80 mm
+ * → `0.2 * 80 = 16 mm` which is below the 30 mm floor. Offset stays 30.
+ * Used to pin the floor-branch behaviour explicitly.
+ */
+function makeTallHalves(): { upper: Manifold; lower: Manifold } {
+  const upper = toplevel.Manifold.cube([30, 40, 30], true).translate([0, 20, 0]);
+  const lower = toplevel.Manifold.cube([30, 40, 30], true).translate([0, -20, 0]);
+  return { upper, lower };
+}
+
+/**
+ * Build a VERY tall pair — 200 mm upper + 200 mm lower → combined
+ * height 400 mm → `0.2 * 400 = 80 mm` which is ABOVE the 30 mm floor.
+ * Offset resolves to 80. Pins the bbox-fraction branch.
+ */
+function makeVeryTallHalves(): { upper: Manifold; lower: Manifold } {
+  const upper = toplevel.Manifold.cube([30, 200, 30], true).translate([0, 100, 0]);
+  const lower = toplevel.Manifold.cube([30, 200, 30], true).translate([0, -100, 0]);
+  return { upper, lower };
+}
+
+describe('setSilicone — basic install', () => {
+  test('places two Mesh children under the silicone group', async () => {
+    const scene = createScene();
+    const halves = makeHalves();
+
+    const result = await setSilicone(scene, halves);
+
+    const group = getSiliconeGroup(scene);
+    const meshChildren = group.children.filter((c) => (c as Mesh).isMesh);
+    expect(meshChildren.length).toBe(2);
+
+    // The returned meshes are exactly the two children — no duplication.
+    expect(meshChildren).toContain(result.upperMesh);
+    expect(meshChildren).toContain(result.lowerMesh);
+  });
+
+  test('installs the expected material on each mesh', async () => {
+    const scene = createScene();
+    const halves = makeHalves();
+
+    const { upperMesh, lowerMesh } = await setSilicone(scene, halves);
+
+    for (const mesh of [upperMesh, lowerMesh]) {
+      const mat = mesh.material as MeshStandardMaterial;
+      expect(mat).toBeInstanceOf(MeshStandardMaterial);
+      expect(mat.color.getHex()).toBe(0x4a9eff);
+      expect(mat.transparent).toBe(true);
+      expect(mat.opacity).toBeCloseTo(0.35, 5);
+      expect(mat.side).toBe(DoubleSide);
+      expect(mat.depthWrite).toBe(false);
+      expect(mat.roughness).toBeCloseTo(0.6, 5);
+      expect(mat.metalness).toBeCloseTo(0.0, 5);
+    }
+  });
+
+  test('halves render at world origin (no group-level transform)', async () => {
+    const scene = createScene();
+    const halves = makeHalves();
+
+    await setSilicone(scene, halves);
+
+    const group = getSiliconeGroup(scene);
+    // Group position must be identity: the generator applies the view
+    // transform internally, so doubling it here would mis-align the
+    // halves with the visible master.
+    expect(group.position.x).toBe(0);
+    expect(group.position.y).toBe(0);
+    expect(group.position.z).toBe(0);
+    expect(group.quaternion.x).toBe(0);
+    expect(group.quaternion.y).toBe(0);
+    expect(group.quaternion.z).toBe(0);
+    expect(group.quaternion.w).toBe(1);
+    expect(group.scale.x).toBe(1);
+    expect(group.scale.y).toBe(1);
+    expect(group.scale.z).toBe(1);
+  });
+
+  test('returned bbox is the union of both halves', async () => {
+    const scene = createScene();
+    const halves = makeHalves();
+
+    const { bbox } = await setSilicone(scene, halves);
+
+    // Upper: Y in [0, 10], Lower: Y in [-10, 0]. Both extend X/Z ±10.
+    // Union should be X∈[-10,10], Y∈[-10,10], Z∈[-10,10].
+    expect(bbox.min.x).toBeCloseTo(-10, 4);
+    expect(bbox.min.y).toBeCloseTo(-10, 4);
+    expect(bbox.min.z).toBeCloseTo(-10, 4);
+    expect(bbox.max.x).toBeCloseTo(10, 4);
+    expect(bbox.max.y).toBeCloseTo(10, 4);
+    expect(bbox.max.z).toBeCloseTo(10, 4);
+  });
+
+  test('caches both Manifolds on the group userData for later disposal', async () => {
+    const scene = createScene();
+    const halves = makeHalves();
+
+    await setSilicone(scene, halves);
+
+    const group = getSiliconeGroup(scene);
+    expect(group.userData[SILICONE_UPPER_MANIFOLD_KEY]).toBe(halves.upper);
+    expect(group.userData[SILICONE_LOWER_MANIFOLD_KEY]).toBe(halves.lower);
+  });
+
+  test('hasSilicone reports true after setSilicone', async () => {
+    const scene = createScene();
+    expect(hasSilicone(scene)).toBe(false);
+    await setSilicone(scene, makeHalves());
+    expect(hasSilicone(scene)).toBe(true);
+  });
+});
+
+describe('setSilicone — replacement (no accumulation)', () => {
+  test('second setSilicone replaces the first pair, does not accumulate', async () => {
+    const scene = createScene();
+    const first = makeHalves();
+    await setSilicone(scene, first);
+
+    // Spy the dispose path: replace the old Manifolds' `.delete()` with a
+    // stub so we can observe the eviction. We have to wrap AFTER install
+    // because the cache receives the real handles pre-replacement.
+    const firstUpperDelete = vi.fn(first.upper.delete.bind(first.upper));
+    const firstLowerDelete = vi.fn(first.lower.delete.bind(first.lower));
+    first.upper.delete = firstUpperDelete;
+    first.lower.delete = firstLowerDelete;
+
+    const second = makeHalves();
+    await setSilicone(scene, second);
+
+    const group = getSiliconeGroup(scene);
+    const meshChildren = group.children.filter((c) => (c as Mesh).isMesh);
+    expect(meshChildren.length).toBe(2);
+
+    // Previous Manifolds were released.
+    expect(firstUpperDelete).toHaveBeenCalledTimes(1);
+    expect(firstLowerDelete).toHaveBeenCalledTimes(1);
+
+    // New Manifolds are cached.
+    expect(group.userData[SILICONE_UPPER_MANIFOLD_KEY]).toBe(second.upper);
+    expect(group.userData[SILICONE_LOWER_MANIFOLD_KEY]).toBe(second.lower);
+  });
+
+  test('generate × 3 leaves exactly two meshes + two cached Manifolds', async () => {
+    const scene = createScene();
+    const group = getSiliconeGroup(scene);
+
+    for (let i = 0; i < 3; i++) {
+      await setSilicone(scene, makeHalves());
+      const meshes = group.children.filter((c) => (c as Mesh).isMesh);
+      expect(meshes.length).toBe(2);
+      expect(group.userData[SILICONE_UPPER_MANIFOLD_KEY]).toBeDefined();
+      expect(group.userData[SILICONE_LOWER_MANIFOLD_KEY]).toBeDefined();
+    }
+  });
+});
+
+describe('clearSilicone', () => {
+  test('removes meshes, disposes GPU resources, and deletes cached Manifolds', async () => {
+    const scene = createScene();
+    const halves = makeHalves();
+    const upperDelete = vi.fn(halves.upper.delete.bind(halves.upper));
+    const lowerDelete = vi.fn(halves.lower.delete.bind(halves.lower));
+    halves.upper.delete = upperDelete;
+    halves.lower.delete = lowerDelete;
+
+    const { upperMesh, lowerMesh } = await setSilicone(scene, halves);
+
+    // Snapshot the geometry + material dispose paths as spies BEFORE
+    // clear, so we can confirm the teardown fires the right disposers.
+    const upperGeomDispose = vi.spyOn(upperMesh.geometry, 'dispose');
+    const lowerGeomDispose = vi.spyOn(lowerMesh.geometry, 'dispose');
+    const upperMatDispose = vi.spyOn(
+      upperMesh.material as MeshStandardMaterial,
+      'dispose',
+    );
+    const lowerMatDispose = vi.spyOn(
+      lowerMesh.material as MeshStandardMaterial,
+      'dispose',
+    );
+
+    clearSilicone(scene);
+
+    const group = getSiliconeGroup(scene);
+    const meshes = group.children.filter((c) => (c as Mesh).isMesh);
+    expect(meshes.length).toBe(0);
+
+    expect(upperGeomDispose).toHaveBeenCalledTimes(1);
+    expect(lowerGeomDispose).toHaveBeenCalledTimes(1);
+    expect(upperMatDispose).toHaveBeenCalledTimes(1);
+    expect(lowerMatDispose).toHaveBeenCalledTimes(1);
+    expect(upperDelete).toHaveBeenCalledTimes(1);
+    expect(lowerDelete).toHaveBeenCalledTimes(1);
+
+    // Cached Manifold slots are cleared.
+    expect(group.userData[SILICONE_UPPER_MANIFOLD_KEY]).toBeUndefined();
+    expect(group.userData[SILICONE_LOWER_MANIFOLD_KEY]).toBeUndefined();
+    expect(hasSilicone(scene)).toBe(false);
+  });
+
+  test('is idempotent on an empty scene (no silicone installed)', () => {
+    const scene = createScene();
+    expect(() => clearSilicone(scene)).not.toThrow();
+    expect(() => clearSilicone(scene)).not.toThrow();
+    expect(hasSilicone(scene)).toBe(false);
+  });
+
+  test('is idempotent after a successful install + clear (double-clear)', async () => {
+    const scene = createScene();
+    await setSilicone(scene, makeHalves());
+    clearSilicone(scene);
+    // Second clear must not throw even though the cached slots are gone.
+    expect(() => clearSilicone(scene)).not.toThrow();
+  });
+});
+
+describe('setExplodedView', () => {
+  test('fraction=1 places upper at +offset, lower at −offset; floor branch', async () => {
+    const scene = createScene();
+    await setSilicone(scene, makeHalves());
+    const group = getSiliconeGroup(scene);
+    const upperMesh = group.children.find(
+      (c) => c.userData['tag'] === 'silicone-upper',
+    ) as Mesh;
+    const lowerMesh = group.children.find(
+      (c) => c.userData['tag'] === 'silicone-lower',
+    ) as Mesh;
+
+    // makeHalves has bbox height 20 → 0.2*20 = 4, floor = 30 → offset=30.
+    setExplodedView(scene, true);
+    advanceRaf(300); // past the 250 ms tween.
+
+    expect(upperMesh.position.y).toBeCloseTo(30, 4);
+    expect(lowerMesh.position.y).toBeCloseTo(-30, 4);
+
+    setExplodedView(scene, false);
+    advanceRaf(300);
+
+    expect(upperMesh.position.y).toBeCloseTo(0, 4);
+    expect(lowerMesh.position.y).toBeCloseTo(0, 4);
+  });
+
+  test('offset honours bbox-fraction branch when 0.2 * height > 30 mm', async () => {
+    const scene = createScene();
+    await setSilicone(scene, makeVeryTallHalves());
+    const group = getSiliconeGroup(scene);
+    const upperMesh = group.children.find(
+      (c) => c.userData['tag'] === 'silicone-upper',
+    ) as Mesh;
+    const lowerMesh = group.children.find(
+      (c) => c.userData['tag'] === 'silicone-lower',
+    ) as Mesh;
+
+    // makeVeryTallHalves: Y in [-200, 200] → height 400 → 0.2*400 = 80.
+    setExplodedView(scene, true);
+    advanceRaf(300);
+
+    expect(upperMesh.position.y).toBeCloseTo(80, 4);
+    expect(lowerMesh.position.y).toBeCloseTo(-80, 4);
+  });
+
+  test('offset uses the 30 mm floor when 0.2 * height < 30', async () => {
+    const scene = createScene();
+    await setSilicone(scene, makeTallHalves());
+    const group = getSiliconeGroup(scene);
+    const upperMesh = group.children.find(
+      (c) => c.userData['tag'] === 'silicone-upper',
+    ) as Mesh;
+    const lowerMesh = group.children.find(
+      (c) => c.userData['tag'] === 'silicone-lower',
+    ) as Mesh;
+
+    // makeTallHalves: Y in [-40, 40] → height 80 → 0.2*80 = 16 → floor = 30.
+    setExplodedView(scene, true);
+    advanceRaf(300);
+
+    expect(upperMesh.position.y).toBeCloseTo(30, 4);
+    expect(lowerMesh.position.y).toBeCloseTo(-30, 4);
+  });
+
+  test('no-op when no silicone is installed (defence-in-depth)', () => {
+    const scene = createScene();
+    expect(() => setExplodedView(scene, true)).not.toThrow();
+    expect(() => setExplodedView(scene, false)).not.toThrow();
+  });
+
+  test('a fresh setSilicone resets to collapsed (fraction=0) even after exploded', async () => {
+    const scene = createScene();
+    await setSilicone(scene, makeHalves());
+    setExplodedView(scene, true);
+    advanceRaf(300);
+
+    // Install a new pair.
+    await setSilicone(scene, makeHalves());
+    const group = getSiliconeGroup(scene);
+    const upperMesh = group.children.find(
+      (c) => c.userData['tag'] === 'silicone-upper',
+    ) as Mesh;
+    const lowerMesh = group.children.find(
+      (c) => c.userData['tag'] === 'silicone-lower',
+    ) as Mesh;
+
+    // New halves start collapsed (y=0) without a manual setExplodedView(false).
+    // `toBeCloseTo` accepts both +0 and -0 since -0 × offset rounds to -0 on
+    // the initial applyFraction(0) call.
+    expect(upperMesh.position.y).toBeCloseTo(0, 6);
+    expect(lowerMesh.position.y).toBeCloseTo(0, 6);
+  });
+});
+
+// -- Fake RAF helpers --------------------------------------------------------
+//
+// The tween inside silicone.ts uses `requestAnimationFrame` + `performance.now`
+// directly. Vitest's default `node` environment supplies real implementations
+// — but they rely on wall-clock ms which makes the 250 ms tween test flaky.
+// We monkey-patch both so the test can advance time deterministically.
+
+let rafCallbacks: Map<number, FrameRequestCallback>;
+let rafCounter: number;
+let fakeNow: number;
+let originalRaf: typeof globalThis.requestAnimationFrame;
+let originalCancel: typeof globalThis.cancelAnimationFrame;
+let originalNow: typeof performance.now;
+
+beforeEach(() => {
+  rafCallbacks = new Map();
+  rafCounter = 1;
+  fakeNow = 0;
+  originalRaf = globalThis.requestAnimationFrame;
+  originalCancel = globalThis.cancelAnimationFrame;
+  originalNow = performance.now.bind(performance);
+
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback): number => {
+    const id = rafCounter++;
+    rafCallbacks.set(id, cb);
+    return id;
+  }) as typeof globalThis.requestAnimationFrame;
+
+  globalThis.cancelAnimationFrame = ((id: number): void => {
+    rafCallbacks.delete(id);
+  }) as typeof globalThis.cancelAnimationFrame;
+
+  performance.now = () => fakeNow;
+});
+
+afterEach(() => {
+  globalThis.requestAnimationFrame = originalRaf;
+  globalThis.cancelAnimationFrame = originalCancel;
+  performance.now = originalNow;
+});
+
+/**
+ * Advance the fake clock by `ms` milliseconds, firing any pending RAF
+ * callbacks at the end. The tween inside `silicone.ts` schedules itself
+ * recursively; we drain the callback queue in a loop so the test sees
+ * the final frame even if the tween re-schedules mid-step.
+ */
+function advanceRaf(ms: number): void {
+  fakeNow += ms;
+  // Drain up to 100 nested RAF schedules — the tween only recurses per
+  // frame, so 100 is far more than enough for any 250 ms animation.
+  for (let i = 0; i < 100; i++) {
+    const pending = [...rafCallbacks];
+    if (pending.length === 0) return;
+    rafCallbacks.clear();
+    for (const [, cb] of pending) cb(fakeNow);
+  }
+}

--- a/tests/renderer/ui/explodedViewToggle.test.ts
+++ b/tests/renderer/ui/explodedViewToggle.test.ts
@@ -1,0 +1,149 @@
+// tests/renderer/ui/explodedViewToggle.test.ts
+//
+// @vitest-environment happy-dom
+//
+// Unit tests for the Exploded-view toolbar toggle (`src/renderer/ui/
+// explodedViewToggle.ts`, issue #47). The toggle is state-driven — its
+// job is to reflect scene-side state back into an aria-pressed button
+// and fire a callback on user flips. Pins:
+//
+//   1. Starts disabled + not-pressed.
+//   2. setEnabled(true) → button clickable; click fires onToggle(true)
+//      and flips aria-pressed to true.
+//   3. Second click fires onToggle(false) and flips aria-pressed back.
+//   4. setEnabled(false) while pressed must force pressed=false (AC:
+//      "silicone cleared → toggle goes back to disabled + off").
+//   5. Clicks while disabled are swallowed (no callback).
+//   6. setActive is a programmatic flip — does NOT fire onToggle.
+//
+// Mirrors the `placeOnFaceToggle` test shape so conventions stay in sync.
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { initI18n } from '@/renderer/i18n';
+import { mountExplodedViewToggle } from '@/renderer/ui/explodedViewToggle';
+
+beforeEach(() => {
+  // Fresh DOM per test so data-testid queries don't collide.
+  document.body.innerHTML = '';
+  // i18n must be initialised so the button label resolves.
+  initI18n();
+});
+
+function mount(): {
+  host: HTMLElement;
+  toggle: ReturnType<typeof mountExplodedViewToggle>;
+  onToggle: ReturnType<typeof vi.fn<(active: boolean) => void>>;
+} {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  const onToggle = vi.fn<(active: boolean) => void>();
+  const toggle = mountExplodedViewToggle(host, { onToggle });
+  return { host, toggle, onToggle };
+}
+
+function getBtn(): HTMLButtonElement {
+  const btn = document.querySelector<HTMLButtonElement>(
+    '[data-testid="exploded-view-toggle"]',
+  );
+  if (!btn) throw new Error('exploded-view-toggle button missing');
+  return btn;
+}
+
+describe('mountExplodedViewToggle — initial state', () => {
+  test('starts disabled + not-pressed', () => {
+    const { toggle } = mount();
+    const btn = getBtn();
+    expect(btn.disabled).toBe(true);
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+    expect(toggle.isActive()).toBe(false);
+  });
+
+  test('renders the localised label + title', () => {
+    mount();
+    const btn = getBtn();
+    expect(btn.textContent).toBe('Exploded view');
+    expect(btn.title).toBe(
+      'Show the two silicone halves moved apart so the cavity is visible',
+    );
+  });
+});
+
+describe('mountExplodedViewToggle — click flow', () => {
+  test('setEnabled(true) → click fires onToggle(true) and flips aria-pressed', () => {
+    const { toggle, onToggle } = mount();
+    toggle.setEnabled(true);
+    const btn = getBtn();
+    expect(btn.disabled).toBe(false);
+
+    btn.click();
+    expect(onToggle).toHaveBeenCalledWith(true);
+    expect(btn.getAttribute('aria-pressed')).toBe('true');
+    expect(toggle.isActive()).toBe(true);
+  });
+
+  test('second click flips back to unpressed', () => {
+    const { toggle, onToggle } = mount();
+    toggle.setEnabled(true);
+    const btn = getBtn();
+
+    btn.click();
+    btn.click();
+
+    expect(onToggle).toHaveBeenNthCalledWith(1, true);
+    expect(onToggle).toHaveBeenNthCalledWith(2, false);
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+    expect(toggle.isActive()).toBe(false);
+  });
+
+  test('clicks while disabled are swallowed', () => {
+    const { onToggle } = mount();
+    // Toggle remains disabled — default state.
+    const btn = getBtn();
+    btn.click();
+    expect(onToggle).not.toHaveBeenCalled();
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+  });
+});
+
+describe('mountExplodedViewToggle — state propagation', () => {
+  test('setEnabled(false) while pressed forces pressed=false', () => {
+    const { toggle } = mount();
+    toggle.setEnabled(true);
+    getBtn().click();
+    expect(toggle.isActive()).toBe(true);
+
+    toggle.setEnabled(false);
+    const btn = getBtn();
+    expect(btn.disabled).toBe(true);
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+    expect(toggle.isActive()).toBe(false);
+  });
+
+  test('setActive is a programmatic flip and does NOT fire onToggle', () => {
+    const { toggle, onToggle } = mount();
+    toggle.setEnabled(true);
+    toggle.setActive(true);
+    const btn = getBtn();
+    expect(btn.getAttribute('aria-pressed')).toBe('true');
+    expect(toggle.isActive()).toBe(true);
+    expect(onToggle).not.toHaveBeenCalled();
+
+    toggle.setActive(false);
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+});
+
+describe('mountExplodedViewToggle — destroy', () => {
+  test('removes the button from the DOM', () => {
+    const { toggle } = mount();
+    expect(
+      document.querySelector('[data-testid="exploded-view-toggle"]'),
+    ).not.toBeNull();
+    toggle.destroy();
+    expect(
+      document.querySelector('[data-testid="exploded-view-toggle"]'),
+    ).toBeNull();
+  });
+});

--- a/tests/renderer/ui/generateInvalidation.test.ts
+++ b/tests/renderer/ui/generateInvalidation.test.ts
@@ -208,3 +208,38 @@ describe('attachGenerateInvalidation — epoch bump (QA blocker 2)', () => {
     expect(getGenerateEpoch()).toBe(startEpoch);
   });
 });
+
+describe('attachGenerateInvalidation — clearSilicone hook (issue #47)', () => {
+  test('calls clearSilicone on every valid commit event', () => {
+    const { topbar, generateButton } = makeMocks();
+    const clearSilicone = vi.fn<() => void>();
+    attachAndTrack(topbar, generateButton, { clearSilicone });
+
+    dispatchCommittedEvent(true);
+    expect(clearSilicone).toHaveBeenCalledTimes(1);
+
+    dispatchCommittedEvent(false);
+    expect(clearSilicone).toHaveBeenCalledTimes(2);
+
+    dispatchCommittedEvent(true);
+    expect(clearSilicone).toHaveBeenCalledTimes(3);
+  });
+
+  test('does NOT call clearSilicone on non-boolean detail', () => {
+    const { topbar, generateButton } = makeMocks();
+    const clearSilicone = vi.fn<() => void>();
+    attachAndTrack(topbar, generateButton, { clearSilicone });
+
+    dispatchCommittedEvent('nope');
+    dispatchCommittedEvent(undefined);
+    dispatchCommittedEvent({ bogus: true });
+
+    expect(clearSilicone).not.toHaveBeenCalled();
+  });
+
+  test('clearSilicone is optional — absence does not throw', () => {
+    const { topbar, generateButton } = makeMocks();
+    attachAndTrack(topbar, generateButton);
+    expect(() => dispatchCommittedEvent(true)).not.toThrow();
+  });
+});

--- a/tests/renderer/ui/generateOrchestrator.test.ts
+++ b/tests/renderer/ui/generateOrchestrator.test.ts
@@ -275,6 +275,123 @@ describe('generateOrchestrator — mid-flight LAY_FLAT_COMMITTED_EVENT race (QA 
   });
 });
 
+describe('generateOrchestrator — scene hand-off (issue #47)', () => {
+  test('happy path with scene sink: halves are handed off, orchestrator does NOT .delete()', async () => {
+    const { topbar, button } = makeMocks();
+    const master = {} as Manifold;
+    const d = deferred<SiliconeShellResult>();
+    const sceneSetSilicone = vi.fn<
+      (halves: { upper: Manifold; lower: Manifold }) => Promise<{ bbox: unknown }>
+    >().mockResolvedValue({ bbox: { min: [0, 0, 0], max: [1, 1, 1] } });
+    const onSiliconeInstalled = vi.fn<(result: unknown) => void>();
+
+    const orchestrator = createGenerateOrchestrator({
+      getMaster: () => master,
+      getParameters: () => DEFAULT_PARAMETERS,
+      getViewTransform: () => new Matrix4(),
+      generate: () => d.promise,
+      topbar,
+      button,
+      scene: { setSilicone: sceneSetSilicone },
+      onSiliconeInstalled,
+      logger: { error: () => {} },
+    });
+
+    const runPromise = orchestrator.run();
+    const result = makeResult();
+    d.resolve(result);
+    await runPromise;
+
+    // Scene sink was handed both Manifolds.
+    expect(sceneSetSilicone).toHaveBeenCalledTimes(1);
+    expect(sceneSetSilicone).toHaveBeenCalledWith({
+      upper: result.siliconeUpperHalf,
+      lower: result.siliconeLowerHalf,
+    });
+    // Ownership transferred → orchestrator does NOT .delete().
+    expect(result.siliconeUpperHalf.delete).not.toHaveBeenCalled();
+    expect(result.siliconeLowerHalf.delete).not.toHaveBeenCalled();
+    // Camera re-frame hook fired once with the setSilicone result.
+    expect(onSiliconeInstalled).toHaveBeenCalledTimes(1);
+    expect(onSiliconeInstalled).toHaveBeenCalledWith({
+      bbox: { min: [0, 0, 0], max: [1, 1, 1] },
+    });
+    // Volumes still push to the topbar on the happy path.
+    expect(topbar.setSiliconeVolume).toHaveBeenCalledWith(STALE_SILICONE_MM3);
+    expect(topbar.setResinVolume).toHaveBeenCalledWith(STALE_RESIN_MM3);
+  });
+
+  test('stale drop still .delete()s the halves even with scene sink wired', async () => {
+    const { topbar, button } = makeMocks();
+    const master = {} as Manifold;
+    const d = deferred<SiliconeShellResult>();
+    const sceneSetSilicone = vi.fn<
+      (halves: { upper: Manifold; lower: Manifold }) => Promise<unknown>
+    >();
+
+    const orchestrator = createGenerateOrchestrator({
+      getMaster: () => master,
+      getParameters: () => DEFAULT_PARAMETERS,
+      getViewTransform: () => new Matrix4(),
+      generate: () => d.promise,
+      topbar,
+      button,
+      scene: { setSilicone: sceneSetSilicone },
+      logger: { error: () => {} },
+    });
+
+    const runPromise = orchestrator.run();
+
+    // Force staleness by bumping the shared epoch externally — same
+    // technique `attachGenerateInvalidation` uses in production.
+    const { bumpGenerateEpoch } = await import(
+      '@/renderer/ui/generateEpoch'
+    );
+    bumpGenerateEpoch();
+
+    const result = makeResult();
+    d.resolve(result);
+    await runPromise;
+
+    // Staleness drop: halves were .delete()'d and the scene sink was
+    // never called (ownership never transferred).
+    expect(result.siliconeUpperHalf.delete).toHaveBeenCalledTimes(1);
+    expect(result.siliconeLowerHalf.delete).toHaveBeenCalledTimes(1);
+    expect(sceneSetSilicone).not.toHaveBeenCalled();
+  });
+
+  test('scene.setSilicone rejection surfaces via button.setError', async () => {
+    const { topbar, button } = makeMocks();
+    const master = {} as Manifold;
+    const d = deferred<SiliconeShellResult>();
+    // Scene sink REJECTS (geometry-adapter failure). Per the ownership
+    // contract, the sink is responsible for having already disposed
+    // both half-Manifolds before throwing.
+    const sceneSetSilicone = vi.fn<
+      (halves: { upper: Manifold; lower: Manifold }) => Promise<unknown>
+    >().mockRejectedValue(new Error('adapter boom'));
+
+    const orchestrator = createGenerateOrchestrator({
+      getMaster: () => master,
+      getParameters: () => DEFAULT_PARAMETERS,
+      getViewTransform: () => new Matrix4(),
+      generate: () => d.promise,
+      topbar,
+      button,
+      scene: { setSilicone: sceneSetSilicone },
+      logger: { error: () => {} },
+    });
+
+    const runPromise = orchestrator.run();
+    d.resolve(makeResult());
+    await runPromise;
+
+    expect(button.setError).toHaveBeenLastCalledWith('adapter boom');
+    // Busy cleared on the finally-block.
+    expect(button.setBusy).toHaveBeenLastCalledWith(false);
+  });
+});
+
 describe('generateOrchestrator — pre-flight failures', () => {
   test('missing master surfaces an error without raising busy', async () => {
     const { topbar, button } = makeMocks();

--- a/tests/visual/silicone-exploded.spec.ts
+++ b/tests/visual/silicone-exploded.spec.ts
@@ -1,0 +1,165 @@
+// tests/visual/silicone-exploded.spec.ts
+//
+// Visual regression: mini-figurine master + silicone halves + exploded-view
+// toggle ON. Exercises the full preview pipeline for issue #47.
+//
+// Because `generateSiliconeShell` itself takes 2-3 s on the mini-figurine,
+// we drive the full pipeline through the same `window.__testHooks` surface
+// the E2E spec uses. Determinism: Chromium is launched with SwiftShader
+// (configured in `playwright.config.ts` visual project) and the clock is
+// frozen before snapshotting.
+//
+// First-run behaviour: this spec ships its first golden on the first green
+// CI run. Per ADR-003 §B visual regression is advisory for 2 weeks after
+// first green, so the missing-golden failure does not block PR merge.
+
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const RENDERER_URL = 'http://localhost:5174/?test=1';
+const FIXTURE_PATH = resolve(
+  __dirname,
+  '..',
+  'fixtures',
+  'meshes',
+  'mini-figurine.stl',
+);
+
+test.describe('visual — silicone preview + exploded view', () => {
+  test('mini-figurine + silicone halves + exploded view ON', async ({ page }) => {
+    // 90 s timeout — the generator takes 2-3 s on warm machines, up to
+    // ~5-8 s on a cold Chromium under SwiftShader. Headroom for CI.
+    test.setTimeout(90_000);
+
+    await page.clock.install({ time: new Date('2026-04-18T00:00:00Z') });
+    await page.addInitScript(() => {
+      (window as unknown as { api: Record<string, unknown> }).api = {
+        getVersion: () => Promise.resolve('0.0.0'),
+        openStl: () => Promise.resolve({ canceled: true }),
+        saveStl: () => Promise.resolve({ canceled: true }),
+      };
+    });
+
+    await page.goto(RENDERER_URL);
+
+    // Wait for viewport + UI mount.
+    await page.waitForFunction(
+      () => {
+        const hooks = (
+          window as unknown as {
+            __testHooks?: {
+              viewportReady?: boolean;
+              viewport?: unknown;
+              explodedView?: unknown;
+            };
+          }
+        ).__testHooks;
+        return !!(hooks?.viewportReady && hooks?.viewport && hooks?.explodedView);
+      },
+      undefined,
+      { timeout: 15_000 },
+    );
+
+    // Hand the fixture bytes to the viewport's setMaster helper.
+    const fixtureBytes = readFileSync(FIXTURE_PATH);
+    const byteArray = Array.from(fixtureBytes);
+    await page.evaluate(async (bytes: number[]) => {
+      const u8 = new Uint8Array(bytes);
+      const ab = u8.buffer.slice(u8.byteOffset, u8.byteOffset + u8.byteLength);
+      type SetMasterHooks = {
+        viewport?: {
+          setMaster: (buf: ArrayBuffer) => Promise<unknown>;
+        };
+      };
+      const hooks = (window as unknown as { __testHooks?: SetMasterHooks })
+        .__testHooks;
+      if (!hooks?.viewport) throw new Error('viewport hook missing');
+      await hooks.viewport.setMaster(ab);
+    }, byteArray);
+
+    // Drive a synthetic lay-flat commit by manipulating the master group's
+    // quaternion directly. We don't need a face-accurate rotation here —
+    // the lay-flat controller's commit flag is what the Generate-mold
+    // button gates on. We just need committed=true. The simplest path is
+    // to go through the viewport's face-picking API, but driving the
+    // camera + click across SwiftShader is fragile. Instead: bypass to
+    // `notifyMasterReset` + a direct commit via the controller isn't
+    // exposed, so we dispatch `LAY_FLAT_COMMITTED_EVENT` with detail=true
+    // — the Generate button subscription keys off that event for its
+    // enabled state, and the orchestrator doesn't read the lay-flat
+    // controller's `isCommitted()` directly.
+    await page.evaluate(() => {
+      const event = new CustomEvent('lay-flat-committed', { detail: true });
+      document.dispatchEvent(event);
+    });
+
+    // Click Generate via the test hook (no click coords needed).
+    await page.evaluate(() => {
+      const btn = document.querySelector<HTMLButtonElement>(
+        '[data-testid="generate-btn"]',
+      );
+      if (!btn) throw new Error('generate-btn missing');
+      btn.click();
+    });
+
+    // Wait for the generator to finish — volumes populate.
+    await page.waitForFunction(
+      () => {
+        const el = document.querySelector<HTMLElement>(
+          '[data-testid="silicone-volume-value"]',
+        );
+        return el?.textContent && el.textContent !== 'Click Generate';
+      },
+      undefined,
+      { timeout: 60_000 },
+    );
+
+    // Wait for silicone to actually be in the scene.
+    await page.waitForFunction(
+      () => {
+        type Obj = { userData?: Record<string, unknown> };
+        type SceneHook = {
+          scene?: { traverse: (cb: (obj: Obj) => void) => void };
+        };
+        const hooks = (window as unknown as { __testHooks?: SceneHook })
+          .__testHooks;
+        if (!hooks?.scene) return false;
+        let count = 0;
+        hooks.scene.traverse((obj) => {
+          const tag = obj.userData?.['tag'];
+          if (tag === 'silicone-upper' || tag === 'silicone-lower') count += 1;
+        });
+        return count === 2;
+      },
+      undefined,
+      { timeout: 10_000 },
+    );
+
+    // Flip exploded view on via the UI toggle + wait for the tween to
+    // complete (250 ms + slop).
+    await page.evaluate(() => {
+      type Hooks = {
+        explodedView?: { setEnabled: (v: boolean) => void };
+        viewport?: { setExplodedView: (v: boolean) => void };
+      };
+      const hooks = (window as unknown as { __testHooks?: Hooks })
+        .__testHooks;
+      // Ensure the toggle is enabled (the orchestrator's installed hook
+      // drives this, but belt-and-braces for visual determinism).
+      hooks?.explodedView?.setEnabled(true);
+      // Fire the scene-side tween directly — this is what a click
+      // eventually does. Running it from the test bypasses any pointer
+      // plumbing SwiftShader jitter.
+      hooks?.viewport?.setExplodedView(true);
+    });
+    await page.clock.runFor(400);
+
+    await expect(page).toHaveScreenshot('silicone-exploded.png', {
+      maxDiffPixelRatio: 0.01,
+      threshold: 0.15,
+      animations: 'disabled',
+      fullPage: false,
+    });
+  });
+});


### PR DESCRIPTION
Closes #47.

## Summary
- New `src/renderer/scene/silicone.ts` module owning the silicone-preview lifecycle: `setSilicone`, `clearSilicone`, `setExplodedView` + `hasSilicone`. Mirrors the `scene/master.ts` swap pattern (dispose geometry + material + `.delete()` old Manifolds before installing new).
- Silicone group (`userData.tag === 'silicone'`) added to the scene skeleton in `scene/index.ts`. The halves render at world origin — the generator bakes the view transform into the Manifolds, so no group-level rotation/translation is compounded.
- Translucent material per issue spec: `MeshStandardMaterial({ color: 0x4a9eff, transparent: true, opacity: 0.35, side: DoubleSide, depthWrite: false, roughness: 0.6, metalness: 0.0 })`. Master reads through cleanly.
- `generateOrchestrator.ts` now has an optional `scene` sink + `onSiliconeInstalled` hook. Happy-path: halves hand off to `scene.setSilicone` (ownership transfers; no `.delete()` in the orchestrator). Staleness-drop + error paths keep `.delete()` — the ownership transfer only happens when the halves actually reach the scene. The older orchestrator tests that omit `scene` still work because the module falls back to the original dispose-after-volume-compute behaviour.
- `attachGenerateInvalidation` gains an optional `clearSilicone` hook called after the epoch bump + volume-null on every `LAY_FLAT_COMMITTED_EVENT` — so commit, reset, and new-STL all tear down the silicone preview alongside the topbar numbers.
- New `src/renderer/ui/explodedViewToggle.ts` — toolbar button next to Place on face. Aria-pressed convention; disable-forces-off; i18n keys under `explodedView.*`. Wired in `main.ts` to enable on `onSiliconeInstalled` and disable on the `clearSilicone` callback.
- Viewport handle exposes `setSilicone` / `clearSilicone` / `setExplodedView`. `setSilicone` unions the silicone bbox with the master-group bbox and calls `frameToBox3` so the camera frames the whole result after Generate.
- `loadMasterFromBuffer` (#46 shared path) now calls `viewport.clearSilicone()` + resets the exploded-view toggle alongside its other state-reset work.
- Exploded-view tween: lightweight RAF loop inside `silicone.ts`, linear ease, 250 ms, offset = `max(30 mm, 0.2 * bboxHeight_mm)`. Mid-flight reversals re-seed the tween from the current fraction so a user who flips the toggle back before the animation completes doesn't see a snap. No new tween library.

## Test coverage
- `tests/renderer/scene/silicone.test.ts` — 16 cases: two-mesh install, material pinning, world-origin rendering, bbox union return, manifold caching, replacement atomicity, generate-x-3 no-accumulation, `clearSilicone` teardown (geometry + material + `.delete()`), idempotent double-clear, exploded-view floor branch (30 mm), bbox-fraction branch (0.2 * 400 = 80 mm), fresh-install resets to collapsed.
- `tests/renderer/ui/explodedViewToggle.test.ts` — 8 cases for initial state, click flow, aria-pressed, disable-forces-off, setActive is programmatic (no callback), destroy.
- `tests/renderer/ui/generateInvalidation.test.ts` — 3 new cases for the `clearSilicone` hook.
- `tests/renderer/ui/generateOrchestrator.test.ts` — 3 new cases for scene hand-off, stale-drop still disposes, scene rejection routes through setError.
- `tests/e2e/silicone-preview.spec.ts` — load → commit → Generate → `window.__testHooks.scene.traverse` assertion for two silicone meshes → click exploded-view → wait 300 ms → assert upper mesh worldY > 20 mm → re-commit → assert meshes gone + toggle disabled.
- `tests/visual/silicone-exploded.spec.ts` — new golden for `mini-figurine + silicone halves + exploded view ON` (advisory per ADR-003 §B).

## Acceptance criteria
- [x] After a successful Generate, both silicone halves render as translucent blue meshes in the viewport.
- [x] Master remains visible through the translucent silicone (`depthWrite: false`).
- [x] Silicone halves are in world space, aligned with the oriented master.
- [x] Exploded-view toggle appears in the toolbar, disabled until silicone is present.
- [x] Toggling exploded view animates upper half up and lower half down over ~250 ms.
- [x] Toggling back collapses the halves with the same tween.
- [x] Generate × 3 leaves exactly two meshes + two cached Manifolds (unit test covers this).
- [x] Committing another face → silicone disappears, toggle back to disabled + off.
- [x] Loading a new STL → silicone disappears.
- [x] Every staleness path `.delete()`s the Manifolds — orchestrator and scene-module both tested.
- [x] All unit tests for the new module + toggle + orchestrator + invalidation changes.
- [x] Playwright E2E spec walks the full generate → exploded-view → re-commit flow.
- [x] Playwright visual snapshot for `mini-figurine + silicone + exploded view ON`.
- [x] All existing tests still pass — `pnpm test` is green (277 passed, 1 skipped).
- [x] No new runtime dep. No CSP / Electron security / `vite.config.ts` / `.claude/skills/**` changes.

## QA sign-off
Pending `qa-engineer` review.

## Test plan
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green
- [x] `pnpm test` — 277 passed, 1 skipped
- [x] `pnpm build:renderer` — succeeds
- [ ] `pnpm test:e2e` — runs on windows-latest CI
- [ ] `pnpm test:visual` — advisory; new golden will be produced on first green CI run

## Screenshots / GIFs
The visual-regression spec `tests/visual/silicone-exploded.spec.ts` ships the first golden on CI. Until then, the exploded translucent blue halves + visible master through them is the visual payoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)