### PR TITLE
feat(geometry): cone + keyhole registration key styles (#57)

### DIFF
--- a/src/geometry/generateMold.ts
+++ b/src/geometry/generateMold.ts
@@ -384,17 +384,11 @@ export async function generateSiliconeShell(
     );
   }
 
-  // Wave 3 (issue #55): validate key style + sprue/vent ordering + vent
-  // count range. All pre-Manifold so bad input costs zero WASM heap.
-  if (
-    parameters.registrationKeyStyle === 'cone' ||
-    parameters.registrationKeyStyle === 'keyhole'
-  ) {
-    throw new InvalidParametersError(
-      `generateSiliconeShell: registrationKeyStyle='${parameters.registrationKeyStyle}' ` +
-        `is not implemented yet in v1 — use 'asymmetric-hemi' (the default)`,
-    );
-  }
+  // Wave 3 (issue #55) + issue #57: all three registrationKeyStyle values
+  // (`asymmetric-hemi`, `cone`, `keyhole`) are now implemented — the
+  // dispatch is in `stampRegistrationKeys`. Validate sprue/vent ordering
+  // and vent count range here (pre-Manifold so bad input costs zero
+  // WASM heap).
   if (!sprueVentDiameterRatioIsValid(parameters)) {
     throw new InvalidParametersError(
       `generateSiliconeShell: sprueDiameter_mm=${parameters.sprueDiameter_mm} ` +
@@ -574,6 +568,7 @@ export async function generateSiliconeShell(
               shellBbox,
               partingY,
               parameters.wallThickness_mm,
+              parameters.registrationKeyStyle,
             );
             // Swap refs: old halves are no longer the "current" ones —
             // release them, then take ownership of the keyed ones.

--- a/src/geometry/index.ts
+++ b/src/geometry/index.ts
@@ -23,10 +23,13 @@ export {
   GeometryError,
   computeKeyDiameter,
   computeKeyLayout,
+  keyholeDirectionForIndex,
   resolveKeyOffsets,
   stampRegistrationKeys,
-  type RegistrationKeysResult,
+  type KeyholeRadialDirection,
   type RegistrationKeyLayout,
+  type RegistrationKeysResult,
+  type RegistrationKeyStyle,
 } from './registrationKeys';
 export {
   MIN_VENT_SEPARATION_MM,

--- a/src/geometry/registrationKeys.ts
+++ b/src/geometry/registrationKeys.ts
@@ -1,8 +1,9 @@
 // src/geometry/registrationKeys.ts
 //
-// Registration-key stamping — Phase 3c Wave 3 (issue #55, step 3).
+// Registration-key stamping — Phase 3c Wave 3 (issue #55) + issue #57
+// (cone + keyhole key styles).
 //
-// Places three hemispherical "keys" along the parting plane (horizontal at
+// Places three registration "keys" along the parting plane (horizontal at
 // `shellBbox` mid-Y from Waves 1-2) that protrude from the lower silicone
 // half and recess into the upper silicone half. Two symmetric keys sit on
 // ±X in the XZ plane; a third asymmetric key sits on +Z alone. The
@@ -10,44 +11,76 @@
 // about Y moves the +Z key to −Z, where the lower half has no matching
 // protrusion, so the halves will not mate.
 //
-// Locked design decisions (from issue #55, do NOT re-litigate):
-//   - Only `asymmetric-hemi` style this wave; `cone` + `keyhole` throw
-//     `InvalidParametersError` upstream at the generator entry.
+// Locked design decisions (layout + sizing, from issue #55):
 //   - 3 keys: (-0.35·ringWidth_X, 0), (+0.35·ringWidth_X, 0), (0, +0.35·ringWidth_Z).
-//   - Hemisphere diameter = min(4.0, 0.3·wallThickness_mm).
+//   - Key diameter = min(4.0, 0.3·wallThickness_mm).
 //   - Inside-ring constraint: `|coord| < ringWidth/2 − radius − 1.0 mm`
 //     with 1 mm clearance to the silicone outer face.
 //   - Clamp inward if the default 0.35 multiplier overshoots the safe zone;
 //     throw `GeometryError` if no valid placement exists.
 //
-// Clamping formula (agent-chosen, documented here and in the PR body):
+// Key styles (issue #55 + #57):
 //
-//   For each axis we compute the maximum multiplier `m_max` such that the
-//   key stays inside the safe zone:
+//   - `asymmetric-hemi` (#55): a full sphere centred on the parting plane.
+//     Upper half subtracts the upper hemisphere (recess); lower half unions
+//     the upper hemisphere (protrusion). Mating surfaces are exactly the
+//     two hemispheres sharing the parting-plane great circle.
 //
-//     |m · ringWidth/2| <= ringWidth/2 − radius − 1.0
-//     → m_max = (ringWidth/2 − radius − 1.0) / (ringWidth/2)
+//   - `cone` (#57): a "double cone" (two cones base-to-base at the
+//     parting plane), centred on the parting plane. Same
+//     symmetric-about-parting invariant as the sphere → single shared tool
+//     for both halves. Upper half gets a conical recess (tip pointing
+//     UP, into the silicone); lower half gets a conical protrusion
+//     (tip pointing UP, out of the silicone). Cone height = diameter
+//     (rule of thumb — a cone of height < diameter keys too softly, a
+//     cone of height > diameter is harder to demould). Since the tool is
+//     diameter-tall (= radius each side of the parting plane), the below-
+//     parting-plane cone of the "double cone" is already inside the lower
+//     half's material — its union is a no-op on volume, exactly like the
+//     sphere case.
 //
-//   If `m_max <= 0` the ring is narrower than `2·radius + 2.0 mm` on that
-//   axis — we throw `GeometryError("silicone ring too thin...")`. Otherwise
-//   the actual key offset is `min(0.35, m_max) · ringWidth/2`. The default
-//   0.35 multiplier wins when the ring is wide enough; the clamp kicks in
-//   on narrow masters (e.g. the issue's 20×10×10 tall-skinny test case).
+//   - `keyhole` (#57): a radially-oriented keyhole cross-section —
+//     circle + rectangular slot extending outward — extruded
+//     symmetrically across the parting plane. Resists lateral shear
+//     (the rectangular slot locks the halves together against any
+//     sliding pull in the XZ plane). Height = diameter (half above /
+//     half below parting plane). Each of the 3 key positions gets its
+//     own radially-oriented tool: the ±X keys' slots extend outward
+//     along ±X; the +Z key's slot extends outward along +Z. This makes
+//     the keyhole inherently "radial-out" from the master centre, so
+//     the slot bodies of different keys never overlap each other in the
+//     silicone ring.
+//
+// Style tradeoffs summary (documented here + in the PR body):
+//
+//   hemi     : simplest CSG (1 sphere union per key); curves smooth; keys
+//              lightly — halves will slide sideways a bit before the
+//              hemispheres seat. Lowest demould risk.
+//   cone     : 2 cones per key (double-cone). Sharp tip means high
+//              contact pressure on mating → keys positively (hard to
+//              mis-align even by a fraction of a millimetre). Higher
+//              demould risk on a stiff silicone — the sharp tip can
+//              pull a slug on release. Best for users who want tight
+//              repeat alignment.
+//   keyhole  : most complex CSG (1 extrude of a polygon union per key,
+//              3 orientations). Slot geometry resists lateral shear as
+//              well as axial separation. Curved lobe + flat slot walls
+//              → demould comparable to hemi. Best for large masters
+//              where lateral registration is the failure mode.
 //
 // Manifold ownership
 // ------------------
 //
-// Every intermediate Manifold created by this module (hemisphere tools,
-// unions, per-key stamps) is `.delete()`-d inside a `try/finally` before
+// Every intermediate Manifold created by this module (key tools, unions,
+// per-key stamps) is `.delete()`-d inside a `try/finally` before
 // returning. The caller receives exactly TWO fresh Manifolds:
 //   - `updatedUpper` — the upper silicone half minus the key recesses
 //   - `updatedLower` — the lower silicone half plus the key protrusions
 // The ORIGINAL `upperHalf` + `lowerHalf` Manifolds passed in are NOT
 // consumed — the caller still owns them and must `.delete()` them
-// separately. This lets the orchestrator choose whether to replace its
-// half-references or keep the un-keyed versions for debugging.
+// separately.
 
-import type { Manifold, ManifoldToplevel } from 'manifold-3d';
+import type { Manifold, ManifoldToplevel, Polygons, Vec2 } from 'manifold-3d';
 
 import { isManifold } from './adapters';
 import { CIRCULAR_SEGMENTS } from './primitives';
@@ -65,6 +98,13 @@ export class GeometryError extends Error {
     this.name = 'GeometryError';
   }
 }
+
+/**
+ * Registration key styles. Mirrors `RegistrationKeyStyle` in
+ * `src/renderer/state/parameters.ts` — kept local to the geometry module
+ * so `stampRegistrationKeys` does not need to import UI state types.
+ */
+export type RegistrationKeyStyle = 'asymmetric-hemi' | 'cone' | 'keyhole';
 
 /**
  * The default multiplier for key offsets along each ring axis. The key
@@ -95,14 +135,32 @@ export const MAX_KEY_DIAMETER_MM = 4.0;
 export const KEY_DIAMETER_WALL_RATIO = 0.3;
 
 /**
+ * Keyhole rectangular-slot width as a fraction of the circular lobe's
+ * diameter. `0.5` per issue #57 ("slot width = diameter / 2"). Exposed as
+ * a constant so tests can pin the ratio and callers can read it for
+ * documentation.
+ */
+export const KEYHOLE_SLOT_WIDTH_RATIO = 0.5;
+
+/**
+ * Keyhole rectangular-slot length — how far the slot extends radially
+ * outward from the circle centre, as a fraction of the circular lobe's
+ * diameter. `1.0` per issue #57 ("slot length = diameter"). Measured
+ * FROM the circle centre so the slot's outer tip is `diameter` away
+ * from the circle centre; the slot's inner edge lives at `+radius` (it
+ * "docks" onto the circle's far side).
+ */
+export const KEYHOLE_SLOT_LENGTH_RATIO = 1.0;
+
+/**
  * Result of `stampRegistrationKeys`. Contains the two fresh silicone
  * half-Manifolds with keys applied. Caller owns both — `.delete()` each
  * when done.
  */
 export interface RegistrationKeysResult {
-  /** Upper silicone half with three hemispherical recesses. */
+  /** Upper silicone half with three key recesses. */
   readonly updatedUpper: Manifold;
-  /** Lower silicone half with three hemispherical protrusions. */
+  /** Lower silicone half with three key protrusions. */
   readonly updatedLower: Manifold;
 }
 
@@ -196,6 +254,221 @@ function buildKeySphere(toplevel: ManifoldToplevel, radius: number): Manifold {
 }
 
 /**
+ * Build a "double cone" Manifold — two cones joined base-to-base at the
+ * origin (bases on the XZ plane at Y=0, tips at Y=±radius). Axis is +Y.
+ *
+ * Uses the same full-shape-symmetric-about-parting-plane invariant that
+ * `buildKeySphere` relies on: the tool's upper-half cone carves the
+ * upper-silicone-half recess (subtract), and the same tool's upper-half
+ * cone is the lower-silicone-half protrusion (union). The lower-half
+ * cone of the tool lives inside the lower-silicone-half material
+ * (volume no-op on union) and outside the upper-silicone-half material
+ * (volume no-op on subtract) — exactly as the sphere case.
+ *
+ * Cone height — per issue #57 "rule of thumb", height equals diameter
+ * of the base. For a double-cone, each individual cone has
+ * height = diameter / 2 = radius, giving tip-to-tip = diameter = 2·radius.
+ *
+ * Implementation: manifold-3d's `Manifold.cylinder(h, rLow, rHigh, ...)`
+ * with `rHigh = 0` is a cone along +Z, apex UP at `z = h`. We build one
+ * upward cone (apex at +Z), rotate -90° about X so apex becomes +Y, then
+ * union with a mirrored copy (scale Y by −1) to produce a cone pointing
+ * down. The two share the parting-plane disc at Y=0.
+ *
+ * Caller owns the returned Manifold — `.delete()` when done.
+ */
+function buildConeTool(
+  toplevel: ManifoldToplevel,
+  radius: number,
+  segments: number = CIRCULAR_SEGMENTS,
+): Manifold {
+  // Each half of the double cone has height = radius (so the full
+  // double cone is 2·radius = diameter tall).
+  const halfHeight = radius;
+
+  // Build a Z-axis cone, base radius = radius, top radius = 0,
+  // from z=0 (base) up to z=halfHeight (apex). Then rotate -90° about X
+  // so the apex points in +Y and the base sits at Y=0.
+  const upZ = toplevel.Manifold.cylinder(halfHeight, radius, 0, segments, false);
+  let upperCone: Manifold | undefined;
+  let lowerCone: Manifold | undefined;
+  let doubled: Manifold | undefined;
+  try {
+    upperCone = upZ.rotate([-90, 0, 0]);
+    // Mirror through the XZ plane (y = 0) to get the downward-pointing
+    // cone. `scale([1, -1, 1])` inverts Y and flips winding, which
+    // manifold-3d handles correctly (it re-derives winding at output
+    // construction time).
+    lowerCone = upperCone.scale([1, -1, 1]);
+    doubled = toplevel.Manifold.union([upperCone, lowerCone]);
+    // Hand ownership of `doubled` to the caller; local holders drop
+    // theirs.
+    const out = doubled;
+    doubled = undefined;
+    return out;
+  } finally {
+    upZ.delete();
+    if (upperCone) upperCone.delete();
+    if (lowerCone) lowerCone.delete();
+    if (doubled) doubled.delete();
+  }
+}
+
+/**
+ * Radial direction for a keyhole tool's rectangular slot. The slot always
+ * points OUTWARD — away from the master centre — so three keys placed at
+ * (-0.35·ringWidth_X, 0), (+0.35·ringWidth_X, 0), (0, +0.35·ringWidth_Z)
+ * have their slots extending along −X, +X, +Z respectively.
+ */
+export type KeyholeRadialDirection = 'x-pos' | 'x-neg' | 'z-pos';
+
+/**
+ * Build a keyhole-shape Manifold — a circle + a rectangular slot extending
+ * radially outward — extruded symmetrically about the parting plane (Y=0).
+ *
+ * The 2D cross-section looks like a lollipop with the stick extending
+ * outward from one side of the circle:
+ *
+ *     ○────   (for 'x-pos': stick extends along +X from the circle's
+ *              +X side; the circle's centre is at the key's XZ position)
+ *
+ * Circle radius  = `radius` (half the key diameter).
+ * Slot width     = `KEYHOLE_SLOT_WIDTH_RATIO  · diameter = 0.5 · 2·radius = radius`.
+ * Slot length    = `KEYHOLE_SLOT_LENGTH_RATIO · diameter = 1.0 · 2·radius = 2·radius`,
+ *                  measured from the circle centre → the slot's outer
+ *                  tip is at `diameter` (= 2·radius) from the centre.
+ *                  The slot's inner end overlaps the circle's interior
+ *                  (starting at `−radius` from the centre along the
+ *                  radial axis), so the union is genuinely one connected
+ *                  keyhole polygon.
+ * Extrude height = `diameter = 2·radius`, centred on the parting plane
+ *                  → upper half gets radius depth of recess, lower half
+ *                  gets radius of protrusion.
+ *
+ * Implementation:
+ *
+ *   1. Build a 2D polygon with circle approximated by `segments`-gon,
+ *      plus a rectangle. We union them at the `Polygons` level (manifold
+ *      accepts overlapping input polygons and extrudes their union).
+ *   2. `Manifold.extrude(polygons, height, 0, 0, [1, 1], true)` produces
+ *      a Z-axis extrusion centred on Z=0.
+ *   3. Rotate -90° about X: +Z (extrude axis) → +Y, 2D XY plane → XZ plane.
+ *      After this rotation: the polygon originally in XY is now in XZ
+ *      (X unchanged; original +Y → +Z; original -Y → -Z) and extrudes
+ *      along ±Y by half-height. But wait — the sign depends on which
+ *      way we rotate. See code comments below for the working-out.
+ *   4. Rotate about Y to orient the radial slot along the requested axis:
+ *      'x-pos' → no rotation; 'x-neg' → 180° about Y; 'z-pos' → -90°
+ *      about Y.
+ *
+ * Caller owns the returned Manifold — `.delete()` when done.
+ */
+function buildKeyholeTool(
+  toplevel: ManifoldToplevel,
+  radius: number,
+  direction: KeyholeRadialDirection,
+  segments: number = CIRCULAR_SEGMENTS,
+): Manifold {
+  const diameter = 2 * radius;
+  // Step 1: build the 2D keyhole polygon in the XY plane. We place the
+  // circle at the 2D origin and the slot extending along +X. The slot
+  // rectangle:
+  //   - x from -radius (inside the circle) to +diameter (outer tip,
+  //     which is `2·radius` along +X from the circle centre);
+  //   - y from -slotHalfWidth to +slotHalfWidth.
+  // Having the rectangle's inner edge at x = -radius ensures the
+  // rectangle fully overlaps the circle's right half, so after
+  // union the keyhole silhouette is a clean lollipop without any
+  // zero-width seams.
+  const slotWidth = KEYHOLE_SLOT_WIDTH_RATIO * diameter; // = radius
+  const slotOuter = KEYHOLE_SLOT_LENGTH_RATIO * diameter; // = 2·radius
+  const slotInner = -radius; // push inside the circle
+
+  // Circle polygon (n-gon approximation). Wound CCW for manifold-3d's
+  // Positive fill rule to count this as a filled region.
+  const circlePts: Vec2[] = [];
+  for (let i = 0; i < segments; i++) {
+    const theta = (2 * Math.PI * i) / segments;
+    circlePts.push([radius * Math.cos(theta), radius * Math.sin(theta)]);
+  }
+
+  // Rectangle polygon (CCW winding).
+  const slotPts: Vec2[] = [
+    [slotInner, -slotWidth / 2],
+    [slotOuter, -slotWidth / 2],
+    [slotOuter, slotWidth / 2],
+    [slotInner, slotWidth / 2],
+  ];
+
+  // Polygons input: an array of SimplePolygons is interpreted with the
+  // Positive fill rule, which unions overlapping positive contours into
+  // a single filled region. This is exactly what we want for a
+  // circle + rectangle silhouette.
+  const polygons: Polygons = [circlePts, slotPts];
+
+  // Step 2 + 3 + 4: extrude, orient along Y, rotate to target direction.
+  const extruded = toplevel.Manifold.extrude(polygons, diameter, 0, 0, [1, 1], true);
+  let yAligned: Manifold | undefined;
+  let oriented: Manifold | undefined;
+  try {
+    // Extrude output: axis along +Z, cross-section in XY, centred on Z=0.
+    // Rotate so the extrusion axis becomes +Y AND the slot's outward
+    // direction (originally +X in the 2D polygon) remains +X in 3D.
+    //
+    // A +90° rotation about the X axis maps:
+    //   (x, y, z) → (x, -z, y)
+    // i.e. the cross-section's original +Y (tangent to the slot)
+    // becomes −Z in 3D, and the extrusion's original +Z becomes +Y.
+    // The slot's radial direction (originally +X) stays +X. Perfect —
+    // the keyhole now extrudes along ±Y by diameter/2, and its slot
+    // points along +X.
+    yAligned = extruded.rotate([90, 0, 0]);
+
+    // Step 4: rotate about Y to target the requested radial direction.
+    // yAligned's slot currently points along +X. We need:
+    //   'x-pos' → keep as-is (0°)
+    //   'x-neg' → rotate 180° about Y   → +X becomes −X
+    //   'z-pos' → rotate -90° about Y   → +X becomes +Z
+    //     (using manifold-3d's right-hand convention for rotate([_, ay, _])
+    //      which is an active rotation by `ay` degrees about +Y.
+    //      Active rotation of +90° about +Y takes +Z → +X, so −90° takes
+    //      +X → +Z, which is what we want.)
+    let aboutY: number;
+    switch (direction) {
+      case 'x-pos':
+        aboutY = 0;
+        break;
+      case 'x-neg':
+        aboutY = 180;
+        break;
+      case 'z-pos':
+        aboutY = -90;
+        break;
+      default: {
+        // Defensive — TypeScript's exhaustive-switch check covers the
+        // enum, but a caller passing a runtime string bypasses that.
+        const exhaustive: never = direction;
+        throw new Error(`buildKeyholeTool: unknown direction ${String(exhaustive)}`);
+      }
+    }
+    oriented = aboutY === 0 ? yAligned : yAligned.rotate([0, aboutY, 0]);
+
+    // If oriented === yAligned (the aboutY === 0 case), we didn't
+    // allocate a fresh Manifold — clearing `yAligned` would double-free.
+    const out = oriented;
+    oriented = undefined;
+    if (out === yAligned) {
+      yAligned = undefined;
+    }
+    return out;
+  } finally {
+    extruded.delete();
+    if (yAligned) yAligned.delete();
+    if (oriented) oriented.delete();
+  }
+}
+
+/**
  * Minimal validity check — we expect the silicone halves to be valid
  * manifolds on entry (they come straight from `splitByPlane`).
  */
@@ -267,6 +540,31 @@ export function computeKeyLayout(
 }
 
 /**
+ * Radial direction for a keyhole key at the given position index in the
+ * layout returned by `computeKeyLayout`. The positions array is ordered:
+ *   [0] −X key → slot extends along −X
+ *   [1] +X key → slot extends along +X
+ *   [2] +Z key → slot extends along +Z
+ *
+ * Exported for tests that want to verify the per-key orientation logic
+ * without instantiating any Manifold.
+ */
+export function keyholeDirectionForIndex(index: number): KeyholeRadialDirection {
+  switch (index) {
+    case 0:
+      return 'x-neg';
+    case 1:
+      return 'x-pos';
+    case 2:
+      return 'z-pos';
+    default:
+      throw new Error(
+        `keyholeDirectionForIndex: index ${index} is out of range; layout has exactly 3 positions`,
+      );
+  }
+}
+
+/**
  * Stamp three registration keys onto the silicone halves along the parting
  * plane at `partingY`. Returns fresh upper + lower Manifolds with the
  * recesses + protrusions applied.
@@ -275,8 +573,8 @@ export function computeKeyLayout(
  *  - Input `upperHalf` + `lowerHalf` are NOT consumed — caller still owns
  *    them and must `.delete()` them when done.
  *  - Output `updatedUpper` + `updatedLower` are FRESH — caller owns them.
- *  - Every intermediate Manifold (hemispheres, unions) is `.delete()`-d
- *    before returning via `try/finally` blocks.
+ *  - Every intermediate Manifold (tools, unions) is `.delete()`-d before
+ *    returning via `try/finally` blocks.
  *
  * @param toplevel Initialised Manifold toplevel handle.
  * @param upperHalf Upper silicone half from the Wave-1 split. Kept alive by
@@ -285,9 +583,10 @@ export function computeKeyLayout(
  *   by the caller.
  * @param shellBbox AABB of the silicone body (both halves combined) in
  *   the oriented frame. Used to compute ring widths for key positioning.
- * @param partingY Y coordinate of the parting plane — the hemispheres
- *   are positioned so their flat-side sits exactly on this plane.
+ * @param partingY Y coordinate of the parting plane — the tool is
+ *   positioned so its mid-plane sits exactly on this Y.
  * @param wallThickness_mm Silicone wall thickness, for key sizing.
+ * @param style Key shape. Defaults to `'asymmetric-hemi'`.
  * @returns Fresh Manifolds (upper with recesses, lower with protrusions).
  * @throws `GeometryError` if the ring is too thin for any key.
  * @throws `Error` if any CSG step produces a non-manifold result.
@@ -299,6 +598,7 @@ export function stampRegistrationKeys(
   shellBbox: { min: readonly number[]; max: readonly number[] },
   partingY: number,
   wallThickness_mm: number,
+  style: RegistrationKeyStyle = 'asymmetric-hemi',
 ): RegistrationKeysResult {
   assertValid(upperHalf, 'input upper half');
   assertValid(lowerHalf, 'input lower half');
@@ -308,39 +608,64 @@ export function stampRegistrationKeys(
   // Resource-tracking discipline: every Manifold we allocate goes into
   // one of these holders and gets `.delete()`-d by the outer finally.
   // The two OUTPUT Manifolds (updatedUpper / updatedLower) are nulled
-  // out of `outputs[]` once we're ready to hand them to the caller — a
-  // null is a no-op in the cleanup loop.
+  // out once we're ready to hand them to the caller — a null is a
+  // no-op in the cleanup loop.
   const tools: Manifold[] = [];
   let updatedUpper: Manifold | undefined;
   let updatedLower: Manifold | undefined;
   try {
-    // Build one origin-centred sphere "stamp", translate it to each key's
-    // XZ + partingY. Each translate produces a fresh Manifold; we delete
-    // the origin-centred source after all three translations land. The
-    // same tool geometry is used on both halves — the upper half's
-    // subtract carves the protrusion hemisphere, the lower half's union
-    // fills only the above-parting-plane hemisphere (the below-plane
-    // hemisphere is already inside lower-half material). See
-    // `buildKeySphere` JSDoc for why full spheres are preferable to
-    // two-tool hemispheres.
-    const keyOrigin = buildKeySphere(toplevel, layout.radius);
-    tools.push(keyOrigin);
+    // Dispatch on key style. Each branch produces a single `keyUnion`
+    // Manifold — the combined tool covering all 3 key positions — which
+    // we then subtract from the upper half and add to the lower half.
+    //
+    // For 'asymmetric-hemi' and 'cone': all 3 keys share ONE rotation-
+    // symmetric tool, which we translate to each position and union.
+    // For 'keyhole': each of the 3 keys has its own radial orientation,
+    // so we build 3 oriented tools and union them.
+    let keyUnion: Manifold;
 
-    const translated: Manifold[] = [];
-    for (const pos of layout.positions) {
-      const t = keyOrigin.translate([pos.x, partingY, pos.z]);
-      tools.push(t);
-      translated.push(t);
+    if (style === 'asymmetric-hemi' || style === 'cone') {
+      const origin: Manifold =
+        style === 'asymmetric-hemi'
+          ? buildKeySphere(toplevel, layout.radius)
+          : buildConeTool(toplevel, layout.radius);
+      tools.push(origin);
+
+      const translated: Manifold[] = [];
+      for (const pos of layout.positions) {
+        const t = origin.translate([pos.x, partingY, pos.z]);
+        tools.push(t);
+        translated.push(t);
+      }
+      keyUnion = toplevel.Manifold.union(translated);
+    } else if (style === 'keyhole') {
+      // Each position gets its own oriented tool. Build each at origin,
+      // translate to the layout XZ + partingY, push the translated
+      // handle onto `translated` for the final union.
+      const translated: Manifold[] = [];
+      for (let i = 0; i < layout.positions.length; i++) {
+        const pos = layout.positions[i]!;
+        const direction = keyholeDirectionForIndex(i);
+        const oriented = buildKeyholeTool(toplevel, layout.radius, direction);
+        tools.push(oriented);
+        const t = oriented.translate([pos.x, partingY, pos.z]);
+        tools.push(t);
+        translated.push(t);
+      }
+      keyUnion = toplevel.Manifold.union(translated);
+    } else {
+      // Exhaustiveness check — a runtime string bypasses the compile-
+      // time union check, so fail loudly here rather than silently
+      // producing empty keys.
+      const exhaustive: never = style;
+      throw new Error(
+        `stampRegistrationKeys: unknown style ${String(exhaustive)}`,
+      );
     }
-
-    // Union the per-key stamps into a single tool so each half only sees
-    // one boolean op. Single-op avoids per-key kernel noise accumulation
-    // on the mating surfaces.
-    const keyUnion = toplevel.Manifold.union(translated);
     tools.push(keyUnion);
-    assertValid(keyUnion, 'registration-key sphere union');
+    assertValid(keyUnion, `registration-key ${style} union`);
 
-    // Stamp: upper half -= key union (carves three recesses above the
+    // Stamp: upper half −= key union (carves three recesses above the
     // parting plane); lower half += key union (adds three protrusions
     // above the parting plane; the below-plane halves are absorbed).
     updatedUpper = upperHalf.subtract(keyUnion);

--- a/tests/geometry/generateMold.test.ts
+++ b/tests/geometry/generateMold.test.ts
@@ -561,48 +561,73 @@ describe('generateSiliconeShell — validation', () => {
 // ---------------------------------------------------------------------------
 
 describe('generateSiliconeShell — Wave 3 (keys, sprue, vents)', () => {
-  test('rejects cone key style pre-Manifold with InvalidParametersError', async () => {
+  // Issue #57: cone + keyhole key styles are now implemented — a happy-path
+  // full-generate per style confirms the dispatch wires through the
+  // generator. The fine-grained geometry coverage lives in the
+  // `registrationKeys.test.ts` suite.
+  test('generates a watertight mold with cone key style (issue #57)', async () => {
     const toplevel = await initManifold();
     const master = toplevel.Manifold.cube([4, 4, 4], true);
     try {
-      await expect(
-        generateSiliconeShell(
-          master,
-          params({ registrationKeyStyle: 'cone' }),
-          new Matrix4(),
-        ),
-      ).rejects.toThrow(/not implemented yet in v1/);
-      // Error class.
+      const result = await generateSiliconeShell(
+        master,
+        params({ registrationKeyStyle: 'cone', ventCount: 0 }),
+        new Matrix4(),
+      );
       try {
-        await generateSiliconeShell(
-          master,
-          params({ registrationKeyStyle: 'cone' }),
-          new Matrix4(),
-        );
-        throw new Error('expected rejection');
-      } catch (err) {
-        expect((err as Error).name).toBe('InvalidParametersError');
+        expect(isManifold(result.siliconeUpperHalf)).toBe(true);
+        expect(isManifold(result.siliconeLowerHalf)).toBe(true);
+        expect(isManifold(result.basePart)).toBe(true);
+        expect(isManifold(result.topCapPart)).toBe(true);
+        for (const s of result.sideParts) expect(isManifold(s)).toBe(true);
+
+        // Halves sum invariant (kernel-noise-level match).
+        const upperVol = result.siliconeUpperHalf.volume();
+        const lowerVol = result.siliconeLowerHalf.volume();
+        expect(upperVol + lowerVol).toBeCloseTo(result.siliconeVolume_mm3, 3);
+
+        // Resin + silicone volumes positive + finite.
+        expect(result.siliconeVolume_mm3).toBeGreaterThan(0);
+        expect(result.resinVolume_mm3).toBeGreaterThan(0);
+        expect(Number.isFinite(result.resinVolume_mm3)).toBe(true);
+      } finally {
+        disposeAll(result);
       }
     } finally {
       master.delete();
     }
-  });
+  }, 30_000);
 
-  test('rejects keyhole key style pre-Manifold with InvalidParametersError', async () => {
+  test('generates a watertight mold with keyhole key style (issue #57)', async () => {
     const toplevel = await initManifold();
     const master = toplevel.Manifold.cube([4, 4, 4], true);
     try {
-      await expect(
-        generateSiliconeShell(
-          master,
-          params({ registrationKeyStyle: 'keyhole' }),
-          new Matrix4(),
-        ),
-      ).rejects.toThrow(/not implemented yet in v1/);
+      const result = await generateSiliconeShell(
+        master,
+        params({ registrationKeyStyle: 'keyhole', ventCount: 0 }),
+        new Matrix4(),
+      );
+      try {
+        expect(isManifold(result.siliconeUpperHalf)).toBe(true);
+        expect(isManifold(result.siliconeLowerHalf)).toBe(true);
+        expect(isManifold(result.basePart)).toBe(true);
+        expect(isManifold(result.topCapPart)).toBe(true);
+        for (const s of result.sideParts) expect(isManifold(s)).toBe(true);
+
+        const upperVol = result.siliconeUpperHalf.volume();
+        const lowerVol = result.siliconeLowerHalf.volume();
+        expect(upperVol + lowerVol).toBeCloseTo(result.siliconeVolume_mm3, 3);
+
+        expect(result.siliconeVolume_mm3).toBeGreaterThan(0);
+        expect(result.resinVolume_mm3).toBeGreaterThan(0);
+        expect(Number.isFinite(result.resinVolume_mm3)).toBe(true);
+      } finally {
+        disposeAll(result);
+      }
     } finally {
       master.delete();
     }
-  });
+  }, 30_000);
 
   test('rejects ventDiameter >= sprueDiameter pre-Manifold', async () => {
     const toplevel = await initManifold();

--- a/tests/geometry/registrationKeys.test.ts
+++ b/tests/geometry/registrationKeys.test.ts
@@ -10,16 +10,20 @@
 // `generateMold.test.ts`.
 
 import { describe, expect, test } from 'vitest';
+import type { Manifold } from 'manifold-3d';
 
 import { initManifold, isManifold } from '@/geometry';
 import {
   DEFAULT_OFFSET_MULTIPLIER,
   GeometryError,
+  KEYHOLE_SLOT_LENGTH_RATIO,
+  KEYHOLE_SLOT_WIDTH_RATIO,
   KEY_CLEARANCE_MM,
   KEY_DIAMETER_WALL_RATIO,
   MAX_KEY_DIAMETER_MM,
   computeKeyDiameter,
   computeKeyLayout,
+  keyholeDirectionForIndex,
   resolveKeyOffsets,
   stampRegistrationKeys,
 } from '@/geometry/registrationKeys';
@@ -222,6 +226,311 @@ describe('stampRegistrationKeys — end-to-end on minimal cube halves', () => {
     try {
       expect(() =>
         stampRegistrationKeys(toplevel, upper, lower, shellBbox, 0, 10),
+      ).toThrow(GeometryError);
+    } finally {
+      upper.delete();
+      lower.delete();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #57 — cone key style
+// ---------------------------------------------------------------------------
+//
+// The `cone` style uses a "double cone" (two cones base-to-base at the
+// parting plane) as the shared tool — analogous to the sphere tool used
+// by `asymmetric-hemi`. Each protrusion/recess is an upward-pointing
+// cone of height = radius (so the full key diameter-to-tip distance,
+// measured tip-to-tip across the parting plane, is 2·radius =
+// diameter). Expected per-key recess/protrusion volume is the upper
+// cone's volume: (1/3) π r² h, with h = r, so (1/3) π r³.
+
+describe('stampRegistrationKeys — cone style', () => {
+  test('returns watertight halves; volume delta matches 3 cones', async () => {
+    const toplevel = await initManifold();
+    const lowerRaw = toplevel.Manifold.cube([40, 10, 40], false).translate([-20, -10, -20]);
+    const upperRaw = toplevel.Manifold.cube([40, 10, 40], false).translate([-20, 0, -20]);
+    const shellBbox = { min: [-20, -10, -20], max: [20, 10, 20] };
+    const partingY = 0;
+    const wall = 10;
+
+    try {
+      const volUpperBefore = upperRaw.volume();
+      const volLowerBefore = lowerRaw.volume();
+
+      const { updatedUpper, updatedLower } = stampRegistrationKeys(
+        toplevel,
+        upperRaw,
+        lowerRaw,
+        shellBbox,
+        partingY,
+        wall,
+        'cone',
+      );
+
+      try {
+        expect(isManifold(updatedUpper)).toBe(true);
+        expect(isManifold(updatedLower)).toBe(true);
+
+        const rKey = 1.5; // diameter = 3 mm at wall=10 → radius = 1.5
+        // Per-key upper-cone volume = (1/3) π r² h, with h = r = 1.5.
+        // So volume = (1/3) π r³.
+        const coneVol = (1 / 3) * Math.PI * Math.pow(rKey, 3);
+        const threeCones = 3 * coneVol;
+
+        const volUpperAfter = updatedUpper.volume();
+        const volLowerAfter = updatedLower.volume();
+
+        // 32-segment cone facet-chord error is ~1.5% on a 1.5 mm radius
+        // cone. A 5% relative tolerance comfortably covers that plus
+        // kernel noise on union/subtract.
+        const upperDelta = volUpperBefore - volUpperAfter;
+        expect(Math.abs(upperDelta - threeCones) / threeCones).toBeLessThan(0.05);
+        const lowerDelta = volLowerAfter - volLowerBefore;
+        expect(Math.abs(lowerDelta - threeCones) / threeCones).toBeLessThan(0.05);
+      } finally {
+        updatedUpper.delete();
+        updatedLower.delete();
+      }
+    } finally {
+      upperRaw.delete();
+      lowerRaw.delete();
+    }
+  }, 30_000);
+
+  test('asymmetric +Z key: upper-half rotated 180° about Y does not mate with lower half', async () => {
+    // Mirrors the asymmetric-hemi orientation test at the generator level.
+    // If the upper half's +Z recess swaps to −Z under a 180° Y rotation,
+    // the lower half's +Z protrusion is unopposed — re-uniting the two
+    // halves no longer yields the same volume as the upright case.
+    const toplevel = await initManifold();
+    const lowerRaw = toplevel.Manifold.cube([40, 10, 40], false).translate([-20, -10, -20]);
+    const upperRaw = toplevel.Manifold.cube([40, 10, 40], false).translate([-20, 0, -20]);
+    const shellBbox = { min: [-20, -10, -20], max: [20, 10, 20] };
+
+    try {
+      const { updatedUpper, updatedLower } = stampRegistrationKeys(
+        toplevel,
+        upperRaw,
+        lowerRaw,
+        shellBbox,
+        0,
+        10,
+        'cone',
+      );
+
+      let rotatedUpper: Manifold | undefined;
+      let upright: Manifold | undefined;
+      let rotatedUnion: Manifold | undefined;
+      try {
+        upright = toplevel.Manifold.union([updatedUpper, updatedLower]);
+        rotatedUpper = updatedUpper.rotate([0, 180, 0]);
+        rotatedUnion = toplevel.Manifold.union([rotatedUpper, updatedLower]);
+
+        const uprightVol = upright.volume();
+        const rotatedVol = rotatedUnion.volume();
+        expect(Math.abs(uprightVol - rotatedVol)).toBeGreaterThan(1e-2);
+      } finally {
+        if (upright) upright.delete();
+        if (rotatedUpper) rotatedUpper.delete();
+        if (rotatedUnion) rotatedUnion.delete();
+        updatedUpper.delete();
+        updatedLower.delete();
+      }
+    } finally {
+      upperRaw.delete();
+      lowerRaw.delete();
+    }
+  }, 30_000);
+
+  test('throws GeometryError on a tall-skinny bbox (same clamp branch as hemi)', async () => {
+    const toplevel = await initManifold();
+    const lower = toplevel.Manifold.cube([4, 10, 40], false).translate([-2, -10, -20]);
+    const upper = toplevel.Manifold.cube([4, 10, 40], false).translate([-2, 0, -20]);
+    const shellBbox = { min: [-2, -10, -20], max: [2, 10, 20] };
+    try {
+      expect(() =>
+        stampRegistrationKeys(toplevel, upper, lower, shellBbox, 0, 10, 'cone'),
+      ).toThrow(GeometryError);
+    } finally {
+      upper.delete();
+      lower.delete();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #57 — keyhole key style
+// ---------------------------------------------------------------------------
+//
+// The `keyhole` tool is a radially-oriented circle + rectangular slot
+// extruded symmetrically across the parting plane. Per-key cross-section
+// area = π r² (circle) + slot-rect-area − circle-rect-overlap. The
+// rectangle extends from x = −radius to x = +diameter with width =
+// radius (centred on y=0 in the 2D cross-section). The overlap between
+// circle + rectangle is HARD to close-form because the rectangle's
+// −radius edge sits INSIDE the circle. Rather than hand-derive the
+// exact volume, we assert:
+//
+//   1. Both halves remain watertight manifolds after stamping.
+//   2. Upper half LOSES volume; lower half GAINS volume (sign invariants).
+//   3. The absolute volume delta is between one sphere-hemi volume
+//      (a lower bound — the circle alone matches the hemi case) and
+//      three times the tool's full-extrude volume (an upper bound —
+//      no two keys' slots overlap in the silicone ring).
+//   4. The 180°-about-Y rotation test proves the asymmetric +Z key is
+//      honoured.
+
+describe('keyholeDirectionForIndex', () => {
+  test('maps layout indices to the correct radial direction', () => {
+    expect(keyholeDirectionForIndex(0)).toBe('x-neg'); // −X key
+    expect(keyholeDirectionForIndex(1)).toBe('x-pos'); // +X key
+    expect(keyholeDirectionForIndex(2)).toBe('z-pos'); // +Z key
+  });
+
+  test('throws on out-of-range indices', () => {
+    expect(() => keyholeDirectionForIndex(-1)).toThrow(/out of range/);
+    expect(() => keyholeDirectionForIndex(3)).toThrow(/out of range/);
+  });
+
+  test('pins the slot-width + slot-length ratio constants', () => {
+    // Issue #57: slot width = diameter / 2, slot length = diameter.
+    expect(KEYHOLE_SLOT_WIDTH_RATIO).toBe(0.5);
+    expect(KEYHOLE_SLOT_LENGTH_RATIO).toBe(1.0);
+  });
+});
+
+describe('stampRegistrationKeys — keyhole style', () => {
+  test('returns watertight halves; volume delta is bounded and has the right sign', async () => {
+    const toplevel = await initManifold();
+    const lowerRaw = toplevel.Manifold.cube([40, 10, 40], false).translate([-20, -10, -20]);
+    const upperRaw = toplevel.Manifold.cube([40, 10, 40], false).translate([-20, 0, -20]);
+    const shellBbox = { min: [-20, -10, -20], max: [20, 10, 20] };
+
+    try {
+      const volUpperBefore = upperRaw.volume();
+      const volLowerBefore = lowerRaw.volume();
+
+      const { updatedUpper, updatedLower } = stampRegistrationKeys(
+        toplevel,
+        upperRaw,
+        lowerRaw,
+        shellBbox,
+        0,
+        10,
+        'keyhole',
+      );
+
+      try {
+        expect(isManifold(updatedUpper)).toBe(true);
+        expect(isManifold(updatedLower)).toBe(true);
+
+        // Per-key tool's upper half (above parting) volume:
+        //   tool cross-section area = πr² (circle) + slot_rect_area -
+        //                             circle∩slot_rect_area.
+        //
+        // Analytic bounds (per key, upper-half only — depth = diameter/2 = r):
+        //   Lower bound on area: the circle alone = π r²
+        //     → upper-half volume ≥ π r² × r = π r³
+        //   Upper bound on area: circle + full slot rect with no overlap
+        //     slot width = r, slot length outer = 2r, slot length inner = -r
+        //     slot rect area = r × (2r - (-r)) = r × 3r = 3 r² → WRONG,
+        //     correct slot rect area = width × total_length = r × 3r = 3r².
+        //     + circle = π r². Total < 3r² + π r² ≈ 6.14 r².
+        //     → upper-half volume ≤ 6.14 r³.
+        //
+        // For r = 1.5: π r³ ≈ 10.6 mm³;
+        //              6.14 r³ ≈ 20.7 mm³ per key upper-half; × 3 keys
+        //              = [31.8, 62.2] mm³ for the 3-key delta.
+        const rKey = 1.5;
+        const threeLowerBound = 3 * Math.PI * Math.pow(rKey, 3);
+        // Upper bound: circle + slot area (no overlap correction). The
+        // rectangle extends from x = -r to x = +2r, so its area = 3r × r = 3r²;
+        // plus circle π r². Total per-key area ≤ (3 + π) r². Times depth r,
+        // times 3 keys.
+        const threeUpperBound = 3 * (3 + Math.PI) * Math.pow(rKey, 3);
+
+        const volUpperAfter = updatedUpper.volume();
+        const volLowerAfter = updatedLower.volume();
+
+        // Upper half: volume DECREASED by the 3-key recess total.
+        const upperDelta = volUpperBefore - volUpperAfter;
+        expect(upperDelta).toBeGreaterThan(0);
+        expect(upperDelta).toBeGreaterThanOrEqual(threeLowerBound * 0.95);
+        expect(upperDelta).toBeLessThanOrEqual(threeUpperBound * 1.05);
+
+        // Lower half: volume INCREASED by the same total (kernel noise
+        // aside). We apply the same bounds — the protrusion volume
+        // equals the recess volume for a parting-plane-symmetric tool.
+        const lowerDelta = volLowerAfter - volLowerBefore;
+        expect(lowerDelta).toBeGreaterThan(0);
+        expect(lowerDelta).toBeGreaterThanOrEqual(threeLowerBound * 0.95);
+        expect(lowerDelta).toBeLessThanOrEqual(threeUpperBound * 1.05);
+
+        // Protrusion volume ≈ recess volume (symmetry about parting plane).
+        // 5% relative bound to absorb kernel / facet noise.
+        expect(Math.abs(upperDelta - lowerDelta) / upperDelta).toBeLessThan(0.05);
+      } finally {
+        updatedUpper.delete();
+        updatedLower.delete();
+      }
+    } finally {
+      upperRaw.delete();
+      lowerRaw.delete();
+    }
+  }, 30_000);
+
+  test('asymmetric +Z key: upper-half rotated 180° about Y does not mate with lower half', async () => {
+    // Same orientation-enforcement invariant as the hemi + cone tests.
+    const toplevel = await initManifold();
+    const lowerRaw = toplevel.Manifold.cube([40, 10, 40], false).translate([-20, -10, -20]);
+    const upperRaw = toplevel.Manifold.cube([40, 10, 40], false).translate([-20, 0, -20]);
+    const shellBbox = { min: [-20, -10, -20], max: [20, 10, 20] };
+
+    try {
+      const { updatedUpper, updatedLower } = stampRegistrationKeys(
+        toplevel,
+        upperRaw,
+        lowerRaw,
+        shellBbox,
+        0,
+        10,
+        'keyhole',
+      );
+
+      let rotatedUpper: Manifold | undefined;
+      let upright: Manifold | undefined;
+      let rotatedUnion: Manifold | undefined;
+      try {
+        upright = toplevel.Manifold.union([updatedUpper, updatedLower]);
+        rotatedUpper = updatedUpper.rotate([0, 180, 0]);
+        rotatedUnion = toplevel.Manifold.union([rotatedUpper, updatedLower]);
+
+        const uprightVol = upright.volume();
+        const rotatedVol = rotatedUnion.volume();
+        expect(Math.abs(uprightVol - rotatedVol)).toBeGreaterThan(1e-2);
+      } finally {
+        if (upright) upright.delete();
+        if (rotatedUpper) rotatedUpper.delete();
+        if (rotatedUnion) rotatedUnion.delete();
+        updatedUpper.delete();
+        updatedLower.delete();
+      }
+    } finally {
+      upperRaw.delete();
+      lowerRaw.delete();
+    }
+  }, 30_000);
+
+  test('throws GeometryError on a tall-skinny bbox (same clamp branch as hemi)', async () => {
+    const toplevel = await initManifold();
+    const lower = toplevel.Manifold.cube([4, 10, 40], false).translate([-2, -10, -20]);
+    const upper = toplevel.Manifold.cube([4, 10, 40], false).translate([-2, 0, -20]);
+    const shellBbox = { min: [-2, -10, -20], max: [2, 10, 20] };
+    try {
+      expect(() =>
+        stampRegistrationKeys(toplevel, upper, lower, shellBbox, 0, 10, 'keyhole'),
       ).toThrow(GeometryError);
     } finally {
       upper.delete();


### PR DESCRIPTION
Closes #57.

## Summary

Implements the two remaining `registrationKeyStyle` values (`cone`, `keyhole`) declared in `MoldParameters` but left pending in Wave 3 (#55, PR #56). Both reuse the existing `stampRegistrationKeys` scaffold — the layout math, clamp formula, and 1 mm safe-ring clearance are unchanged; only the tool geometry (and, for keyhole, per-key radial orientation) differs.

`generateMold.ts` no longer rejects these styles with `InvalidParametersError('not implemented yet in v1')` — the validator's throw for cone/keyhole was removed and the style is now threaded through to `stampRegistrationKeys`.

## Design + tradeoffs (rule-of-thumb dimensions)

All three styles share the same layout, sizing, and clamp formula from Wave 3:
- 3 keys: 2 symmetric on ±X, 1 asymmetric on +Z
- `diameter = min(4.0 mm, 0.3 × wallThickness_mm)` → `radius = diameter / 2`
- 0.35 offset multiplier, clamped inward when the ring is narrow, throws `GeometryError` when the ring is too thin for a key

### `cone`

- **Geometry**: double cone (two cones base-to-base at the parting plane). Base radius = `radius`, each cone's height = `radius`, total tip-to-tip = `diameter` (rule of thumb per #57: height = diameter).
- **CSG cost**: 1 cylinder + 1 rotate + 1 mirror + 1 union per tool; then 3 translates + 1 union + 1 subtract + 1 add = same tool-count complexity as hemi. Runtime within noise of hemi on the mini-figurine (see perf table below).
- **Mating invariant**: same single-shared-tool pattern as hemi. The below-parting-plane cone of the double cone is already inside the lower half's material → the add is a no-op there. Above-parting-plane cone carves the upper half's recess exactly equal to the lower half's protrusion.
- **Curve quality**: 32-segment cone, facet chord ~0.3 mm at radius 1.5 — indistinguishable from the sphere at the same segment count.
- **Assembly tradeoff**: sharper contact → keys more positively than hemi (harder to mis-align by a fraction of a mm). Higher demould risk on stiff silicone — the sharp tip can "pull a slug" on release. Best when tight repeat alignment matters.

### `keyhole`

- **Geometry**: radially-oriented circle + rectangular-slot cross-section, extruded along Y centred on the parting plane.
  - Circle radius = `radius` (= `diameter / 2`)
  - Slot width = `diameter / 2` (= `radius`)
  - Slot length from circle centre = `diameter` (slot outer tip sits at `2·radius` outward; inner end at `-radius` so it overlaps the circle's far side and the union is a clean lollipop)
  - Extrude height = `diameter` (half above / half below parting plane)
- **CSG cost**: 1 extrude + 2 rotates per tool × 3 keys + 1 union of translated tools. Extrude is the expensive step; still lands within noise of hemi/cone on the mini-figurine (see table below). Per-key tool differs by `aboutY` orientation angle (`0° / 180° / -90°` for +X / -X / +Z keys).
- **Mating invariant**: extrude is centred on the parting plane, so the sub-parting-plane half sits inside the lower half's material and the union/subtract mirror cleanly.
- **Curve quality**: circle lobe uses the same 32-segment approximation as hemi/cone; slot walls are exact flats.
- **Assembly tradeoff**: the rectangular slot adds lateral-shear resistance the lobes of a hemi or cone cannot provide — pulling the halves sideways in XZ is opposed by the slot's flank walls. Demould risk comparable to hemi (curved lobe + flat slot walls, no sharp tips). Best on large masters where lateral registration is the dominant failure mode.

## Performance (mini-figurine full-pipeline, n=3 local)

| Style             | min     | avg     | max     |
|-------------------|---------|---------|---------|
| asymmetric-hemi   | 2305 ms | 2357 ms | 2458 ms |
| cone              | 2247 ms | 2275 ms | 2309 ms |
| keyhole           | 2245 ms | 2248 ms | 2250 ms |

All three styles land well under the Wave-3-locked 6 500 ms CI budget. LevelSet dominates at ~2 s (cone + keyhole don't touch the SDF path). The key-stamp step itself is ~10–80 ms and does not show a material style-to-style gap.

## Tests

### Acceptance-criteria checklist (from issue #57)

- [x] Unit tests per style — placement, volume identity, asymmetric-orientation check, narrow-ring clamp/throw. `tests/geometry/registrationKeys.test.ts`:
  - `stampRegistrationKeys — cone style` — watertight halves + 3-cone volume delta within 5% of analytic `(1/3) π r³ × 3`
  - `stampRegistrationKeys — cone style` — 180°-about-Y rotation does not mate (asymmetric +Z key enforces orientation)
  - `stampRegistrationKeys — cone style` — tall-skinny bbox throws `GeometryError`
  - `stampRegistrationKeys — keyhole style` — watertight halves + volume delta bounded by analytic lower/upper bounds (circle-only ≤ delta ≤ circle+full-slot)
  - `stampRegistrationKeys — keyhole style` — 180°-about-Y rotation does not mate
  - `stampRegistrationKeys — keyhole style` — tall-skinny bbox throws `GeometryError`
  - `keyholeDirectionForIndex` — maps layout index 0/1/2 to `x-neg / x-pos / z-pos`
- [x] Integration test in `generateMold.test.ts`: one happy-path full-generate per style on a 4 mm cube master — both produce watertight halves + printable parts, halves-sum-invariant holds.
- [x] PR body documents tradeoffs + rule-of-thumb dimensions (above).
- [x] No regression on `asymmetric-hemi` — all 12 pre-existing registrationKeys tests + all Wave-3 generateMold tests still pass.
- [x] Performance budget unchanged — all three styles under 6 500 ms on the mini-figurine full-pipeline.

### Test command output

- `vitest run` (full suite): **354 passed, 1 skipped** (same skip count as pre-change baseline)
- `tsc -b --noEmit`: clean
- `eslint .`: clean

## Files changed

- `src/geometry/registrationKeys.ts` — new `buildConeTool`, `buildKeyholeTool`, `keyholeDirectionForIndex`; `stampRegistrationKeys` now takes a `style: RegistrationKeyStyle` parameter defaulting to `'asymmetric-hemi'` (back-compat for the existing tests)
- `src/geometry/generateMold.ts` — removed the cone+keyhole throw; pass `parameters.registrationKeyStyle` into `stampRegistrationKeys`
- `src/geometry/index.ts` — re-export the new `RegistrationKeyStyle` type + `keyholeDirectionForIndex` / `KeyholeRadialDirection`
- `tests/geometry/registrationKeys.test.ts` — +9 tests covering cone + keyhole
- `tests/geometry/generateMold.test.ts` — replaced the two "rejects with not-implemented-yet" tests with happy-path full-generate tests per style

## Test plan

- [x] `pnpm run test` — green locally (354 passed)
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [ ] CI green across lint/typecheck/unit/geometry/E2E/build
- [ ] `qa-engineer` sign-off

## Ownership + follow-ups

- Manifold ownership audit — every intermediate in `buildConeTool` + `buildKeyholeTool` is `.delete()`-d in `try/finally`; the `generate×3 does not leak` test still passes, so no handles are escaping.
- No follow-up issues surfaced during implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)