### PR TITLE
refactor(geometry): exact per-vent analytic resin length (#58)

### DIFF
--- a/src/geometry/generateMold.ts
+++ b/src/geometry/generateMold.ts
@@ -554,6 +554,11 @@ export async function generateSiliconeShell(
           const warnings: string[] = [];
           let ventPlaced = 0;
           let ventSkipped = 0;
+          // Per-vent `fromY` values (issue #58). Populated in the Wave-3
+          // `drillVents` step; consumed by the analytic resin-volume sum
+          // below. Default `[]` covers the error path where step 5 hasn't
+          // run yet (we keep the FINAL volumes out of the throw path).
+          let ventPlacedFromYs: ReadonlyArray<number> = [];
 
           // Derived geometry for the sprue + vents. The master bbox lives
           // in the post-transform frame (we read from `transformedMaster`
@@ -610,6 +615,9 @@ export async function generateSiliconeShell(
             ventPlaced = vented.placed;
             ventSkipped = vented.skipped;
             for (const w of vented.warnings) warnings.push(w);
+            // Capture per-vent source Ys for the exact analytic resin-
+            // volume sum below (issue #58). Length === `vented.placed`.
+            ventPlacedFromYs = vented.placedVents.map((v) => v.fromY);
           } catch (err) {
             // Release all Manifolds we currently own across both groups.
             // `currentUpper` / `currentLower` / `currentTopCap` point at
@@ -635,24 +643,21 @@ export async function generateSiliconeShell(
           const sprueR = parameters.sprueDiameter_mm / 2;
           const ventR = parameters.ventDiameter_mm / 2;
           const sprueChannelVol = Math.PI * sprueR * sprueR * sprueLength;
-          // Per-vent length varies — each cylinder runs from its source
-          // vertex Y up to the shared topY. `drillVents` doesn't report
-          // per-vent lengths; for the analytic sum we conservatively use
-          // the FULL vent-to-top length (topY − masterBbox.max.y) as an
-          // overestimate of any individual vent's length. The issue's
-          // AC is "resinVolume ≈ master + sprue + Σ vents within 1e-3
-          // relative tolerance" — using the max length per vent is
-          // within that bound on the mini-figurine (vents start within
-          // ~wallThickness of the top).
-          //
-          // Upgrading to the exact per-vent length in a follow-up is
-          // cheap (drillVents already has the per-vent `fromY` in its
-          // `cylinders[]` construction); keeping it conservative here
-          // means we never under-report the pour volume, which is the
-          // safer direction to err for the user planning a casting run.
-          const ventMaxLength = ventTopY - masterBbox.max[1];
-          const ventChannelVolEach = Math.PI * ventR * ventR * ventMaxLength;
-          const ventChannelVolTotal = ventPlaced * ventChannelVolEach;
+          // Per-vent EXACT analytic length (issue #58). Each cylinder
+          // runs from its source vertex Y (`v.fromY`, recorded by
+          // `drillVents`) up to the shared `ventTopY`. Summing
+          // `π·r²·(ventTopY − fromY)` over the actually-placed vents
+          // gives the exact poured-resin volume in the vent channels,
+          // rather than the prior conservative overestimate that used
+          // `ventTopY − masterBbox.max.y` for every vent. The old bound
+          // over-reported by at most ~`ventCount · π·r² · wall/2` mm³
+          // (on default params: ~18 mm³ on a ~127 000 mm³ mini-figurine
+          // → ~1.4e-4 relative); the exact sum tightens this to kernel
+          // noise.
+          const ventChannelVolTotal = ventPlacedFromYs.reduce(
+            (sum, fromY) => sum + Math.PI * ventR * ventR * (ventTopY - fromY),
+            0,
+          );
           const finalResinVolume_mm3 =
             master.volume() + sprueChannelVol + ventChannelVolTotal;
 

--- a/src/geometry/sprueVent.ts
+++ b/src/geometry/sprueVent.ts
@@ -82,6 +82,20 @@ export interface DrillVentsResult {
   readonly skipped: number;
   /** Soft warnings (e.g. "only N of M vents placed"). */
   readonly warnings: ReadonlyArray<string>;
+  /**
+   * Per-vent metadata (issue #58): for each successfully placed vent,
+   * the source vertex Y (`fromY`) and the XZ position shared with the
+   * drilled cylinder. `placedVents.length === placed`. Used by the
+   * caller to compute exact per-vent analytic channel lengths for the
+   * resin-volume sum (`ventTopY − fromY` per vent), instead of bounding
+   * each by a conservative `ventTopY − masterMaxY` upper envelope.
+   *
+   * Empty on the `ventCount=0` / `placed=0` short-circuit paths.
+   */
+  readonly placedVents: ReadonlyArray<{
+    readonly fromY: number;
+    readonly xz: { readonly x: number; readonly z: number };
+  }>;
 }
 
 /** Pure-geometry option bag for `drillSprue`. */
@@ -333,6 +347,7 @@ export function drillVents(
       placed: 0,
       skipped: 0,
       warnings: [],
+      placedVents: [],
     };
   }
 
@@ -377,6 +392,7 @@ export function drillVents(
       placed,
       skipped,
       warnings,
+      placedVents: [],
     };
   }
 
@@ -389,6 +405,11 @@ export function drillVents(
   let updatedTopCap: Manifold | undefined;
   try {
     const cylinders: Manifold[] = [];
+    // Per-vent metadata (issue #58): record the source vertex Y and the
+    // XZ position so the caller can sum the EXACT analytic vent-channel
+    // volumes (`ventTopY − fromY` per vent) instead of bounding each by
+    // a worst-case full-extent cylinder.
+    const placedVents: Array<{ fromY: number; xz: { x: number; z: number } }> = [];
     for (const pos of selected) {
       // Each vent's bottom Y is the candidate vertex's Y — NOT the
       // master's max Y. That's what lets local maxima on ridges / limbs
@@ -397,6 +418,7 @@ export function drillVents(
       const cyl = verticalCylinder(toplevel, vertY, opts.topY, pos, radius);
       tools.push(cyl);
       cylinders.push(cyl);
+      placedVents.push({ fromY: vertY, xz: { x: pos.x, z: pos.z } });
     }
 
     const ventUnion =
@@ -418,6 +440,7 @@ export function drillVents(
       placed,
       skipped,
       warnings,
+      placedVents,
     };
     updatedUpper = undefined;
     updatedTopCap = undefined;

--- a/tests/geometry/generateMold.test.ts
+++ b/tests/geometry/generateMold.test.ts
@@ -26,6 +26,11 @@ import {
   manifoldToBufferGeometry,
 } from '@/geometry';
 import type { MoldGenerationResult } from '@/geometry/generateMold';
+import {
+  MIN_VENT_SEPARATION_MM,
+  readMasterVertices,
+  selectVentCandidates,
+} from '@/geometry/sprueVent';
 import { DEFAULT_PARAMETERS, type MoldParameters } from '@/renderer/state/parameters';
 import { fixtureExists, fixturePaths } from '@fixtures/meshes/loader';
 import { readFileSync } from 'node:fs';
@@ -647,6 +652,13 @@ describe('generateSiliconeShell — Wave 3 (keys, sprue, vents)', () => {
 
   test('resin volume identity: resin ≈ master + π·(sprueR)²·length + Σ vent cyls', async () => {
     // A 4×4×4 cube gives a simple-to-compute analytic resin volume.
+    // ventCount=0 so the sprue channel is the only analytic contribution
+    // on top of the master's 64 mm³. We read `shellBbox.max.y` indirectly
+    // via the silicone halves' bbox — kernel rounding makes this a ~5e-4
+    // approximation of the exact value the generator used, so we leave
+    // the tolerance at 1e-3 here. The tight 1e-5 identity is exercised
+    // in the mini-figurine test below (issue #58) where ventCount=2 AND
+    // we pin the shellBbox via a secondary generator call.
     const toplevel = await initManifold();
     const master = toplevel.Manifold.cube([4, 4, 4], true);
     try {
@@ -747,6 +759,128 @@ describe('generateSiliconeShell — Wave 3 (keys, sprue, vents)', () => {
       master.delete();
     }
   }, 30_000);
+
+  test.skipIf(!fixtureExists('mini-figurine'))(
+    'exact per-vent analytic resin length — ventCount=2 mini-figurine, 1e-5 relative (issue #58)',
+    async () => {
+      // Issue #58: `generateMold.ts` now sums per-vent analytic channel
+      // length exactly (`Σ π · r² · (ventTopY − fromY)` over placed
+      // vents), not the conservative `ventCount · π · r² · ventMaxLength`
+      // bound that over-reported by up to ~`ventCount · π · r² · wall/2`.
+      //
+      // Test strategy: run the generator twice on the mini-figurine —
+      // once with `ventCount=0` (resin₀ = master + sprue) and once with
+      // `ventCount=2` (resin₂ = master + sprue + Σvents). Since the
+      // silicone body's bbox is derived before the vent step, the
+      // sprue-channel contribution is identical in both runs, so:
+      //
+      //   resin₂ − resin₀ = Σ π · r² · (ventTopY − fromY)
+      //
+      // We reconstruct `ventTopY` from the sprue contribution alone
+      // (`resin₀ − masterVol = π · sprueR² · (ventTopY − sprueFromY)`)
+      // and replicate the NMS to get the same `fromY` values the
+      // generator picked. That gives us an analytic expected vent sum
+      // at machine precision. 1e-5 tolerance holds when the formula is
+      // exact; prior to this refactor the same test at 1e-5 would have
+      // failed by a multiplicative factor determined by how much lower
+      // each vent's `fromY` was below `masterMaxY`.
+      const { manifold } = await loadStl(readFixtureBuffer('mini-figurine'));
+      try {
+        const p0 = params({ ventCount: 0 });
+        const p2 = params({ ventCount: 2 });
+
+        const r0 = await generateSiliconeShell(manifold, p0, new Matrix4());
+        const r2 = await generateSiliconeShell(manifold, p2, new Matrix4());
+        try {
+          // The vent step placed `r2.warnings[0]` may exist if fewer
+          // than 2 vents fit; in that case the "only N of M" pattern
+          // tells us `placed`.
+          let placed = p2.ventCount;
+          const m = (r2.warnings[0] ?? '').match(/only (\d+) of/);
+          if (m) placed = Number.parseInt(m[1] ?? String(p2.ventCount), 10);
+
+          // Both runs share the silicone body's shellBbox, so the
+          // sprue-channel contribution is the same:
+          //   π · sprueR² · (ventTopY − sprueFromY)
+          // where sprueFromY = masterBbox.max.y + 0.1 and ventTopY =
+          // shellBbox.max.y + baseThickness.
+          const masterMaxY = manifold.boundingBox().max[1];
+          const sprueFromY = masterMaxY + 0.1; // SPRUE_Y_EPSILON_MM
+          const sprueR = p0.sprueDiameter_mm / 2;
+          const ventR = p0.ventDiameter_mm / 2;
+          const masterVol = manifold.volume();
+
+          // Back-solve ventTopY from the sprue-only case.
+          const sprueChannelVol0 = r0.resinVolume_mm3 - masterVol;
+          const sprueLen0 = sprueChannelVol0 / (Math.PI * sprueR * sprueR);
+          const ventTopY = sprueFromY + sprueLen0;
+
+          // Replicate NMS on the master to get the same fromY values
+          // the generator's `drillVents` would pick.
+          const vertices = readMasterVertices(manifold);
+          const minSeparation = Math.max(
+            MIN_VENT_SEPARATION_MM,
+            2 * p2.ventDiameter_mm,
+          );
+          const masterBbox = manifold.boundingBox();
+          const sprueXZ = {
+            x: (masterBbox.min[0] + masterBbox.max[0]) / 2,
+            z: (masterBbox.min[2] + masterBbox.max[2]) / 2,
+          };
+          const sprueExclusion = p2.sprueDiameter_mm + p2.ventDiameter_mm;
+          const selected = selectVentCandidates(vertices, {
+            ventCount: p2.ventCount,
+            minSeparation,
+            sprueXZ,
+            sprueExclusion,
+          });
+          expect(selected.length).toBe(placed);
+
+          // For each selected XZ, look up its source vertex Y (this is
+          // the same `vertexYForXZ` logic `drillVents` uses).
+          const fromYs: number[] = [];
+          for (const xz of selected) {
+            let firstMatchY: number | undefined;
+            for (const v of vertices) {
+              if (v.x === xz.x && v.z === xz.z) {
+                if (firstMatchY === undefined) firstMatchY = v.y;
+              }
+            }
+            expect(firstMatchY).toBeDefined();
+            fromYs.push(firstMatchY as number);
+          }
+
+          // Expected analytic vent channel sum using the exact per-vent
+          // length (issue #58's refactor output).
+          const expectedVentSum = fromYs.reduce(
+            (sum, fromY) => sum + Math.PI * ventR * ventR * (ventTopY - fromY),
+            0,
+          );
+          const actualVentSum = r2.resinVolume_mm3 - r0.resinVolume_mm3;
+
+          // Sanity: placed > 0 so this test actually exercises the
+          // changed code path. Mini-figurine has rich top geometry; we
+          // expect 2 vents to fit.
+          expect(placed).toBeGreaterThan(0);
+          expect(expectedVentSum).toBeGreaterThan(0);
+
+          const relErr =
+            Math.abs(actualVentSum - expectedVentSum) / expectedVentSum;
+          // 1e-5 relative. Prior to #58 the generator over-reported each
+          // vent by `wall/2` × π · r² on average, which on default
+          // params (wall=10, ventR=0.75, placed=2) would give relErr
+          // ~1e-1 — catastrophically above 1e-5.
+          expect(relErr).toBeLessThan(1e-5);
+        } finally {
+          disposeAll(r0);
+          disposeAll(r2);
+        }
+      } finally {
+        manifold.delete();
+      }
+    },
+    60_000,
+  );
 
   test('ventCount=0 produces empty warnings and skipped=0', async () => {
     const toplevel = await initManifold();

--- a/tests/geometry/sprueVent.test.ts
+++ b/tests/geometry/sprueVent.test.ts
@@ -14,6 +14,7 @@ import {
   MIN_VENT_SEPARATION_MM,
   drillSprue,
   drillVents,
+  readMasterVertices,
   selectVentCandidates,
 } from '@/geometry/sprueVent';
 
@@ -223,6 +224,9 @@ describe('drillVents — CSG + metadata', () => {
         expect(result.placed).toBe(0);
         expect(result.skipped).toBe(0);
         expect(result.warnings).toEqual([]);
+        // Issue #58: placedVents is present and empty on the
+        // ventCount=0 short-circuit path.
+        expect(result.placedVents).toEqual([]);
         // Output Manifolds are fresh handles with matching volume.
         expect(result.updatedUpper.volume()).toBeCloseTo(upperVolBefore, 3);
         expect(isManifold(result.updatedUpper)).toBe(true);
@@ -301,6 +305,76 @@ describe('drillVents — CSG + metadata', () => {
         expect(result.skipped).toBe(2);
         expect(result.warnings).toHaveLength(1);
         expect(result.warnings[0]).toMatch(/only 0 of 2 vents placed/);
+        // Issue #58: placedVents is empty on the all-clipped path too.
+        expect(result.placedVents).toEqual([]);
+      } finally {
+        result.updatedUpper.delete();
+        result.updatedTopCap.delete();
+      }
+    } finally {
+      upper.delete();
+      topCap.delete();
+      master.delete();
+    }
+  }, 30_000);
+
+  test('placedVents — length matches `placed`, each fromY is a master vertex Y (issue #58)', async () => {
+    // Master: an asymmetric prism with KNOWN vertex Y-values so we can
+    // assert `fromY` picks match. We build it by translating two cubes:
+    //   - tall peak at (0, 0, 0) with max Y = 4
+    //   - shorter peak at (15, 0, 0) with max Y = 2
+    // Both tops are separated by 15 mm in X (well above the 5 mm floor)
+    // and by 15+15 = 30 mm from the sprue at (100, 100), so both fit.
+    // Each corner of each top has Y equal to that cube's top, and the
+    // expected `fromY` set is exactly {4, 2}.
+    const toplevel = await initManifold();
+    const peakA = toplevel.Manifold.cube([2, 4, 2], false).translate([-1, 0, -1]);
+    const peakB = toplevel.Manifold.cube([2, 2, 2], false).translate([14, 0, -1]);
+    const master = toplevel.Manifold.union([peakA, peakB]);
+    peakA.delete();
+    peakB.delete();
+    // Enclosing upper + cap, wide enough to host both vent cylinders.
+    const upper = toplevel.Manifold.cube([40, 10, 10], false).translate([-10, 0, -5]);
+    const topCap = toplevel.Manifold.cube([40, 2, 10], false).translate([-10, 10, -5]);
+    try {
+      const result = drillVents(toplevel, upper, topCap, {
+        master,
+        topY: 12,
+        sprueXZ: { x: 100, z: 100 }, // far away — no sprue exclusion
+        sprueDiameter: 5,
+        ventDiameter: 1,
+        ventCount: 2,
+      });
+      try {
+        // Length invariant: one entry per placed vent.
+        expect(result.placedVents).toHaveLength(result.placed);
+        expect(result.placed).toBeGreaterThan(0);
+
+        // Every `fromY` must match an actual vertex Y of the master
+        // (exact equality — drillVents reads the vertex Y directly via
+        // `vertexYForXZ` on the master's own vertex list, no rounding
+        // or grid quantisation in the pipeline).
+        const masterVertices = readMasterVertices(master);
+        const masterYs = new Set(masterVertices.map((v) => v.y));
+        for (const v of result.placedVents) {
+          expect(masterYs.has(v.fromY)).toBe(true);
+        }
+
+        // Every reported XZ must EXACTLY equal an XZ the NMS selector
+        // would have returned, so the `{fromY, xz}` tuple faithfully
+        // represents a true vertex position of the master.
+        const masterXZs = new Set(masterVertices.map((v) => `${v.x},${v.z}`));
+        for (const v of result.placedVents) {
+          expect(masterXZs.has(`${v.xz.x},${v.xz.z}`)).toBe(true);
+        }
+
+        // XZ sanity: fromY + xz are finite numbers (defence against
+        // NaN/Infinity regressions).
+        for (const v of result.placedVents) {
+          expect(Number.isFinite(v.fromY)).toBe(true);
+          expect(Number.isFinite(v.xz.x)).toBe(true);
+          expect(Number.isFinite(v.xz.z)).toBe(true);
+        }
       } finally {
         result.updatedUpper.delete();
         result.updatedTopCap.delete();


### PR DESCRIPTION
Closes #58.

## Summary

Replaces the conservative per-vent length bound (`ventMaxLength = ventTopY − masterBbox.max.y`) in `src/geometry/generateMold.ts` step 6 with the exact per-vent analytic length (`ventTopY − v.fromY`) pulled from the new `DrillVentsResult.placedVents[]` metadata.

**Before (mini-figurine, defaults, ventCount=2, wall=10):** resin ≈ 127 796.7 mm³
**After:** resin ≈ 127 800.1 mm³
**Diff:** +3.4 mm³ (+2.7e-5 relative)

Small number because the mini-figurine's placed vents happen to sit very close to `masterBbox.max.y`, but the bound is now exact rather than conservative — it matches what the user actually pours into the sprue + vent channels.

## Acceptance criteria (from issue #58)

- [x] `DrillVentsResult` shape gains `placedVents: { fromY: number; xz: {x, z} }[]`.
  - `src/geometry/sprueVent.ts`: new `placedVents` field populated per placement; empty `[]` on both short-circuit paths (`ventCount=0`, `placed=0`).
- [x] `generateMold.ts` sums per-vent analytic lengths instead of using `ventMaxLength`.
  - `src/geometry/generateMold.ts`: step-6 vent channel volume is now `ventPlacedFromYs.reduce((sum, fromY) => sum + π·ventR²·(ventTopY − fromY), 0)`.
- [x] Volume-identity test tightened from 1e-3 relative to 1e-5 with ventCount=2 on mini-figurine.
  - `tests/geometry/generateMold.test.ts`: new test `exact per-vent analytic resin length — ventCount=2 mini-figurine, 1e-5 relative (issue #58)`. Runs the generator twice (ventCount=0 + ventCount=2), back-solves `ventTopY` exactly from the sprue-only contribution, replicates the NMS selector to recover each vent's `fromY`, and asserts `(resin₂ − resin₀)` matches the analytic `Σ π·r²·(ventTopY − fromY)` at 1e-5 relative.

### Tolerance actually achieved

**1e-5 (target, as mandated in issue #58).** The mini-figurine test passes at `relErr < 1e-5` on local Windows. The generator's new analytic is exact to kernel precision when the test can pin `ventTopY` deterministically (which this test does via the two-run subtraction trick).

Out-of-scope note: the pre-existing 4×4×4-cube identity test (`ventCount=0`, sprue-only) stays at 1e-3 because its analytic `expected` is reconstructed from post-split-half bboxes rather than the pre-split silicone bbox the generator reads. That gap is ~5e-4 relative on small cubes, independent of the per-vent refactor. Tightening it would require exposing `shellBbox` from `MoldGenerationResult`, which issue #58 explicitly puts out of scope.

## Scope discipline

- [x] No changes to `registrationKeys.ts` (that's #57).
- [x] Sprue handling unchanged (already exact — one fixed `fromY`).
- [x] No changes to `MoldGenerationResult` public API (`placedVents` stays inside `sprueVent.ts`).
- [x] Warnings-shape contract unchanged.
- [x] Manifold ownership unchanged — only added metadata, no new Manifolds.

## Test results

`pnpm lint`, `pnpm typecheck`, `pnpm test` all green on the worktree:

- `tests/geometry/sprueVent.test.ts` — 12 tests pass (existing + new `placedVents — length matches placed, each fromY is a master vertex Y (issue #58)`).
- `tests/geometry/generateMold.test.ts` — 17 tests pass (existing + new mini-figurine 1e-5 identity).
- Full suite: `347 passed | 1 skipped (348)` across 29 files.