### PR TITLE
docs(skills): sync mesh-operations SKILL.md with levelSet perf playbook (#78)

### DIFF
--- a/.claude/skills/mesh-operations/SKILL.md
+++ b/.claude/skills/mesh-operations/SKILL.md
@@ -55,6 +55,22 @@ If an input mesh is non-manifold, `manifold-3d` repairs it silently. **Surface t
 - **Generate (batch)**: target < 500 ms on 50 k-tri masters, < 3 s on 500 k-tri. Beyond 500 k, show progress and allow cancel.
 - **WASM init**: preload `manifold-3d` at app startup. Don't lazy-load on first Generate.
 
+## LevelSet perf playbook (issues #72 / #74 / #75 / #86)
+
+The silicone + print-shell pipeline in `src/geometry/generateMold.ts` calls `Manifold.levelSet` twice on the same master SDF. These optimisations compound to take mini-figurine from ~7.1 s → ~5.2 s (–27% total, –84% on the shell-levelset alone). When editing this path, preserve them:
+
+1. **Unified grid bounds.** Both `levelSet` calls sample the SAME lattice. The shell pass uses `pad = siliconeThickness + printShellThickness`; the silicone pass reuses that same padded bounds. Sharing bounds means sample points collide in the overlap region — precondition for (2).
+
+2. **Quantised-key SDF cache.** The SDF closure wraps a `Map<string, number>` keyed by `round(p · 1e6)` triples. Gives ~50% hit rate by construction on the second pass. Quantum MUST be much tighter than `edgeLength` (1e-6 mm is lossless; `edgeLength/2` would be unsafe — one-quantum SDF errors near BCC edges flip marching-tet classification).
+
+3. **Far-field early-out.** For query points whose AABB distance from the master exceeds `max(|level|) + edgeLength`, the exact SDF value is immaterial — they're always "outside". The closure skips BVH descent and returns a pre-computed constant below the deepest iso-level. ~10% BVH savings on a figurine, ~30% on a compact cube.
+
+4. **Non-axis-aligned parity ray.** The ray cast for inside/outside parity MUST use a prime-ratio direction like `(1, 0.00931, 0.01373).normalize()`, never `(1, 0, 0)`. Axis-aligned rays graze axis-aligned mesh edges and return ambiguous parity counts. Under (1)'s enlarged grid this surfaces as silent topology corruption (extra silicone components at the grid boundary). Prime-ratio direction avoids edges/vertices on non-degenerate meshes.
+
+5. **edgeLength floor** (#71, #86). `max(2.0, siliconeThickness/4)` as the floor. At silicone=5 mm this yields 2.0 mm. Dropping below 1.5 mm makes ubuntu CI blow through the 12 s perf budget. When lowering, add a scaling rule based on master bbox magnitude (#76 tracks this for large masters).
+
+When profiling regressions, instrument via `SdfStats` (cache hit rate, far-skip count, BVH ms). Signal to watch: `shell-levelset-ms / silicone-levelset-ms` — if it's not ~0.15, the cache is broken.
+
 ## Patterns to prefer
 
 - **Single source of truth for geometry**: Manifold instance for compute, `BufferGeometry` for display. Build a thin adapter in `src/geometry/adapters.ts` (create if missing); don't sprinkle conversions across call sites.

--- a/src/geometry/generateMold.ts
+++ b/src/geometry/generateMold.ts
@@ -34,66 +34,16 @@
 //   - Registration keys on future brim interfaces (Wave F).
 //   - Draft-angle application (separate wave).
 //
-// Offset algorithm — `Manifold.levelSet` over a BVH-driven SDF:
+// Offset algorithm + perf playbook:
 //
-//   The `mesh-operations` skill + ADR-002 both prescribe
-//   `Manifold.levelSet` as the quality-path offset for silicone walls.
-//   We use it TWICE against the SAME SDF closure:
-//
-//     Manifold.levelSet(sdf, unifiedBounds, edgeLength, -siliconeThickness)
-//       → silicone outer body
-//     Manifold.levelSet(sdf, unifiedBounds, edgeLength,
-//                       -(siliconeThickness + printShellThickness))
-//       → print-shell outer body
-//
-//   The SDF closure is stateless relative to the level parameter — the
-//   BVH built from the master geometry answers `closestPoint + ray-parity`
-//   the same way for every grid cell regardless of iso-value. So a single
-//   BVH build feeds both levelSet passes.
-//
-//   `edgeLength` governs both the BCC grid spacing AND the output mesh
-//   resolution. Wave C bumps the floor from 1.5 mm to 2.0 mm as the perf
-//   fix #71 — see `resolveEdgeLength` below. At the default silicone
-//   thickness of 5 mm this yields a 2.0 mm grid (down from 1.5 mm), ~60%
-//   fewer cells, bringing the mini-figurine back under the ~4 s CI budget.
-//
-// Issue #74 perf optimisations (this commit):
-//
-//   1. Unified bounds. Pre-#74 the silicone pass ran on a smaller grid
-//      (pad = siliconeThickness) and the shell pass on a larger grid
-//      (pad = siliconeThickness + shellThickness). manifold-3d derives
-//      the sample lattice from `bounds.min/max` with an internal step
-//      that only approximates `edgeLength`, so the two grids shared ZERO
-//      sample points in the overlap region. Using the LARGER bounds for
-//      BOTH calls makes every sample of the second pass a cache-key
-//      collision with a first-pass sample.
-//
-//   2. Quantised-key SDF cache. The SDF closure wraps a
-//      `Map<string, number>` keyed by `round(p·1e6)` triples. Combined
-//      with (1) this gives a 50% cache hit rate by construction — the
-//      shell-levelset cost collapses from ~3.4 s to ~550 ms on the
-//      mini-figurine.
-//
-//   3. Far-field early-out. For query points whose AABB distance from
-//      the master exceeds `max(|level|) + edgeLength`, the exact SDF
-//      value is immaterial to marching-tetrahedra output — they're
-//      always "outside the volume". The closure skips the BVH descent
-//      and returns a pre-computed constant below the deepest iso-level.
-//      Saves another ~10% of BVH work on a figurine, ~30% on a compact
-//      cube.
-//
-//   4. Non-axis-aligned parity ray. The pre-#74 raycast used
-//      `(1, 0, 0)`, which grazes axis-aligned mesh edges and returned
-//      ambiguous parity counts. Under (1)'s enlarged grid this
-//      surfaced as silent topology corruption (extra silicone
-//      components at the grid boundary). A prime-ratio ray direction
-//      never passes exactly through an edge or vertex on
-//      non-degenerate meshes. See `buildMasterSdf` for details.
-//
-//   Net: mini-figurine local wall-clock ~7.1 s → ~5.2 s (~27% faster);
-//   shell-levelset alone ~3.4 s → ~550 ms (~84% faster). CI is
-//   expected to see a similar ratio, bringing the 10 s ubuntu-CI run
-//   under the issue #72 5 s AC target.
+//   The pipeline calls `Manifold.levelSet` TWICE against the SAME SDF
+//   closure (silicone pass, then print-shell pass). See the
+//   mesh-operations skill's "LevelSet perf playbook" section for:
+//     - Unified grid bounds + quantised SDF cache (issue #74 #75).
+//     - Far-field early-out.
+//     - Non-axis-aligned parity ray (#74 topology-corruption fix).
+//     - edgeLength floor (#71 #86).
+//   Preserve those when editing this path.
 
 import { DoubleSide, Ray, Vector3 } from 'three';
 import type { BufferGeometry, Matrix4 } from 'three';


### PR DESCRIPTION
## Summary
- Move the 45-line perf playbook from the top of \`src/geometry/generateMold.ts\` into \`.claude/skills/mesh-operations/SKILL.md\` § LevelSet perf playbook.
- Replace the inline .ts block with a one-paragraph pointer that cites the skill.
- Documents issues #72 / #74 / #75 / #86 in one place for future geometry agents.

Closes #78.

## Test plan
- [x] lint + typecheck clean.
- Pure-docs change — no code logic affected. Existing unit/e2e/visual tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)