### PR TITLE
perf(geometry): adaptive edgeLength for large masters + E+F claw-back (#76 #86)

### DIFF
--- a/src/geometry/brim.ts
+++ b/src/geometry/brim.ts
@@ -91,7 +91,33 @@
 // For `k = 0.5` that is 75 % of the former rectangular-box volume —
 // ~25 % less print material per flange.
 //
-// Construction sequence (post-#96):
+// Issue #86 claw-back — batched diff + union
+// -------------------------------------------
+//
+// Pre-#86 each brim independently subtracted `siliconeOuter` from its
+// prism (one `Manifold.difference` per cut) and then unioned with the
+// running piece (one `Manifold.union` per cut). For sideCount=4 that's
+// 16 boolean ops per `generateSiliconeShell` (4 pieces × 4 ops). The
+// `difference([prism, siliconeOuter])` step was the hot spot because
+// `siliconeOuter` is the expensive levelSet-built master-outset
+// Manifold.
+//
+// Post-#86 each piece batches:
+//   1. Collect all brim prisms for the piece.
+//   2. If >1 prism: merge via `Manifold.union(brimPrisms[])` (cheap —
+//      the prisms only graze each other near the shell junction).
+//   3. Single `Manifold.difference([merged, siliconeOuter])` — the
+//      expensive silicone-cavity subtract runs ONCE per piece.
+//   4. Single `Manifold.union(piece, carved)` — integrate into the
+//      shell piece.
+//
+// Boolean count per piece: 3 instead of 4 (sideCount 3/4), with the
+// expensive per-brim diff collapsed to 1 per piece. Cavity-safety
+// invariant preserved — `difference([union(brims), silicone])` is
+// set-theoretically equivalent to `union([b_i − silicone])` and the
+// ring-fixture `brim.intersect(silicone) < 1 mm³` test still passes.
+//
+// Construction sequence (post-#86, #96):
 //
 //   1. Build `CrossSection.square([brimThickness, ySize], center=true)`
 //      — a centred 2D rectangle in the (X, Y) plane.
@@ -392,19 +418,88 @@ export function addBrim(args: AddBrimArgs): Manifold {
     return piece;
   }
 
-  // `current` is the running Manifold: start with the piece, union each
-  // brim in turn, release the previous handle after each union.
+  // Issue #86 perf claw-back — batched difference + union
+  //
+  // Pre-#86 the loop did per-cut:
+  //
+  //   current = piece
+  //   for each cut:
+  //     build placed                              (3 ops, small)
+  //     carved = difference([placed, siliconeOuter])   <-- EXPENSIVE
+  //     current = union(current, carved)                <-- EXPENSIVE
+  //
+  // For sideCount=4 that's 8 difference calls (one per brim) against
+  // the full siliconeOuter (several-thousand-tri Manifold from the
+  // levelSet pass) + 8 union calls to stitch each brim back onto its
+  // piece. On ubuntu CI the brim phase cost ~1.4 s (mini-figurine,
+  // sideCount=4) — majority on the 8 per-brim differences.
+  //
+  // Post-#86 (this code):
+  //
+  //   current = piece
+  //   for each cut:
+  //     build placed                              (3 ops, small)
+  //     collect placed into brimPrisms[]
+  //
+  //   allBrims = (brimPrisms.length === 1)
+  //     ? brimPrisms[0]
+  //     : Manifold.union(brimPrisms)              <-- cheap merge
+  //                                                   (brims don't
+  //                                                    overlap)
+  //   carved  = difference([allBrims, siliconeOuter])  <-- SINGLE
+  //                                                        expensive
+  //                                                        cavity
+  //                                                        subtract
+  //   return   union([piece, carved])             <-- SINGLE piece
+  //                                                   integration
+  //
+  // Per-piece boolean count drops from 4 (2 diff + 2 union) to 3
+  // (1 merge-union + 1 diff + 1 final union). The diff now runs on
+  // the MERGED brim Manifold rather than each brim separately —
+  // manifold-3d's diff kernel runs BVH-on-A once against BVH-on-B;
+  // combining A once amortises that setup. The two brim prisms in a
+  // sideCount-3/4 piece sit on DIFFERENT cut planes (angles a0 vs
+  // a1, 90-120° apart radially) — they may graze each other near the
+  // shell junction depending on brimThickness + bondOverlap, so the
+  // merge-union is NOT strictly a concatenation. Still, the boundary-
+  // pairing work is bounded to that grazing region (<< the full
+  // brim-vs-silicone pairing cost) and the single-diff amortisation
+  // dominates.
+  //
+  // On sideCount=2 (single cut per piece) the brimPrisms list has
+  // length 1, and we SKIP the cheap merge-union entirely (it would
+  // be a Manifold.union(readonly Manifold[]) with one element, which
+  // would run as a degenerate no-op but we'd still pay the WASM
+  // round-trip). Boolean count per piece: 1 diff + 1 union = 2.
+  //
+  // Safety: the per-brim silicone-cavity carve-out invariant still
+  // holds because `difference([union(brims), siliconeOuter])` is
+  // algebraically equivalent to `union([difference([b0,silicone]),
+  // difference([b1,silicone])])` on the SET-THEORETIC level (distribu-
+  // tive law of set difference over union). The kernel's floating-
+  // point implementation may produce slightly different boundary
+  // vertices at the junction (co-planar face pairing, sub-ULP drift)
+  // but the volume result is identical modulo kernel epsilon, and
+  // the ring-fixture test `brim.intersect(siliconeOuter).volume() <
+  // 1 mm³` still passes.
   //
   // Lifetime invariants tracked for the failure path:
-  //   - `pieceConsumed` flips `true` the first time we release the
-  //     caller's original `piece` (either via `.delete()` inside the
-  //     loop, or — on throw before the first union completes — via
-  //     the catch block below).
-  //   - `tempManifolds` holds every ephemeral brim-prism handle.
+  //   - `pieceConsumed` flips `true` once the final union completes
+  //     (from that point on the output owns piece's volume; releasing
+  //     piece is safe). On throw before the union, piece is released
+  //     by the catch block.
+  //   - `brimPrisms` holds placed brim Manifolds (pre-merge).
+  //   - `mergedBrims` is the post-merge Manifold (or one of the
+  //     brimPrisms on sideCount=2).
+  //   - `carved` is the mergedBrims − siliconeOuter result.
+  //   - `tempManifolds` holds other ephemeral Manifold handles
+  //     (brim-construction intermediates from steps 1-5).
   //   - `tempSections` holds every ephemeral CrossSection handle
   //     (manifold-3d CrossSections are WASM-allocated and must be
   //     explicitly `.delete()`-ed).
-  let current: Manifold = piece;
+  const brimPrisms: Manifold[] = [];
+  let mergedBrims: Manifold | undefined;
+  let carved: Manifold | undefined;
   let pieceConsumed = false;
   const tempManifolds: Manifold[] = [];
   const tempSections: CrossSection[] = [];
@@ -486,47 +581,85 @@ export function addBrim(args: AddBrimArgs): Manifold {
       ]);
       tempManifolds.push(placed);
 
-      // Step 6 (issue #89 fix B): carve the silicone cavity out of
-      // the brim prism. On convex masters this is effectively a
-      // no-op since the narrow radial slab already clears the shell's
-      // outer surface; on non-convex masters (e.g. a figurine with
-      // concave pockets) the brim's inner face can dip INTO the
-      // silicone cavity, and this subtract removes that intrusion.
-      //
-      // `siliconeOuter` is the master offset outward by
-      // `siliconeThickness_mm` — a SOLID Manifold equal to the shell's
-      // inner-cavity volume. `difference([brimPrism, siliconeOuter])`
-      // carves the cavity's volume out of the brim prism. CALLER-
-      // OWNED: `siliconeOuter` is NOT disposed here.
-      const carved = toplevel.Manifold.difference([placed, siliconeOuter]);
-      tempManifolds.push(carved);
-
-      // Step 7: union with the running piece.
-      const unioned = toplevel.Manifold.union(current, carved);
-
-      // Swap running handle. `current` is either the original caller
-      // `piece` (iteration 0) or a prior union result (iteration >= 1);
-      // either way it's safe to release at this point — the new
-      // `unioned` fully contains its volume.
-      safeDeleteM(current);
-      if (current === piece) pieceConsumed = true;
-      current = unioned;
+      // Collect into brimPrisms for the batched silicone-cavity
+      // subtract below. Pre-#86 this step individually subtracted
+      // siliconeOuter from each `placed` prism (one diff per cut).
+      brimPrisms.push(placed);
     }
 
-    // Release every intermediate handle. The final `current` has
-    // absorbed their volume via union.
+    // Step 6 (issue #89 fix B, issue #86 batched): carve the silicone
+    // cavity out of the brim prism(s). On convex masters this is
+    // effectively a no-op since the narrow radial slab already
+    // clears the shell's outer surface; on non-convex masters (e.g.
+    // a figurine with concave pockets) the brim's inner face can
+    // dip INTO the silicone cavity, and this subtract removes that
+    // intrusion.
+    //
+    // `siliconeOuter` is the master offset outward by
+    // `siliconeThickness_mm` — a SOLID Manifold equal to the shell's
+    // inner-cavity volume. CALLER-OWNED: `siliconeOuter` is NOT
+    // disposed here.
+    //
+    // Ring-shell unit test (tests/geometry/brim.test.ts, "brim.
+    // intersect(siliconeOuter).volume() ≈ 0") pins this to < 1 mm³
+    // absolute — pre-#89 it was hundreds of mm³. Removing the
+    // subtract as a perf shortcut (issue #86 lever 1) is UNSAFE
+    // because on the ring fixture the brim inner edge sits INSIDE
+    // the cavity (inner_cavity_radius=5, brim_inner = outerRadius-
+    // bondOverlap = 10-6 = 4). Issue #86 is addressed via lever 2
+    // (batched diff + union) which delivers the claw-back without
+    // touching the cavity-safety invariant.
+    //
+    // Batching: pre-#86 ran a per-brim `difference([brim_i,
+    // siliconeOuter])` call, i.e. 2 diffs per sideCount-3/4 piece
+    // (16 total for a sideCount=4 generate). Post-#86 does a single
+    // diff against the union of brim prisms. Algebraically
+    // equivalent by the distributive law of set-difference over
+    // union — floating-point boundary placement may differ sub-ULP
+    // but the measured volume is identical modulo kernel epsilon.
+    if (brimPrisms.length === 1) {
+      // Single-cut case (sideCount=2). Skip the degenerate merge-
+      // union; feed brim prism straight to the diff.
+      mergedBrims = brimPrisms[0] as Manifold;
+      // Ownership: `mergedBrims` aliases `brimPrisms[0]`. Release it
+      // by emptying `brimPrisms` — the catch/finally trail below
+      // walks `brimPrisms` for teardown and finds nothing, while
+      // `mergedBrims` is released explicitly after the diff.
+      brimPrisms.length = 0;
+    } else {
+      // Multi-cut case (sideCount=3/4). Cheap merge-union of
+      // non-overlapping prisms (pair only meets at the shell's outer
+      // edge, if at all — manifold-3d still handles this fine).
+      mergedBrims = toplevel.Manifold.union(brimPrisms);
+      // brimPrisms entries survive — released in the cleanup below.
+    }
+
+    // Step 7: single silicone-cavity subtract on the merged brims.
+    carved = toplevel.Manifold.difference([mergedBrims, siliconeOuter]);
+
+    // Step 8: single piece integration — union([piece, carved]).
+    // Using the 2-arg form (same cost as the 1-element array form,
+    // but the explicit signature reads cleaner).
+    const result = toplevel.Manifold.union(piece, carved);
+    pieceConsumed = true;
+
+    // Release every intermediate handle. The final `result` has
+    // absorbed the volume of piece + every carved brim.
+    safeDeleteM(piece);
+    safeDeleteM(mergedBrims);
+    safeDeleteM(carved);
+    for (const bp of brimPrisms) safeDeleteM(bp);
     for (const m of tempManifolds) safeDeleteM(m);
     for (const cs of tempSections) safeDeleteCs(cs);
-    return current;
+    return result;
   } catch (err) {
     for (const m of tempManifolds) safeDeleteM(m);
     for (const cs of tempSections) safeDeleteCs(cs);
-    // Release the running `current` if it is NOT the original piece
-    // (either a prior union result that hasn't been consumed by the
-    // next iteration, or the piece itself on an iteration-0 throw).
-    if (current !== piece) {
-      safeDeleteM(current);
+    for (const bp of brimPrisms) safeDeleteM(bp);
+    if (mergedBrims && !brimPrisms.includes(mergedBrims)) {
+      safeDeleteM(mergedBrims);
     }
+    if (carved) safeDeleteM(carved);
     // Always release the original piece — caller's contract is it's
     // consumed regardless of success/failure.
     if (!pieceConsumed) safeDeleteM(piece);

--- a/src/geometry/generateMold.ts
+++ b/src/geometry/generateMold.ts
@@ -184,6 +184,18 @@ const PRINT_SHELL_POUR_EDGE_MM = 3;
 const PRINT_SHELL_POUR_CHANNEL_SLOP_MM = 2;
 
 /**
+ * Target raw-bbox volume (mm³) that tunes the adaptive edgeLength floor
+ * for large masters (issue #76). See `resolveEdgeLength` for the full
+ * derivation + example calculations.
+ *
+ * Picked so that a 200×200×200 mm master lands at edgeLength ≥ 3.0 mm
+ * (cbrt(8e6 / 150_000) ≈ 3.77) while a mini-figurine-sized master
+ * (bboxVol ~140k mm³) stays at the static 2.0 mm floor
+ * (cbrt(140k / 150_000) ≈ 0.98, clamped by the static floor).
+ */
+const ADAPTIVE_EDGELENGTH_TARGET_BBOX_VOL_MM3 = 150_000;
+
+/**
  * LevelSet grid spacing (mm). Tuned for the mini-figurine to land under
  * the CI budget while still giving a visually plausible silicone body.
  *
@@ -201,11 +213,78 @@ const PRINT_SHELL_POUR_CHANNEL_SLOP_MM = 2;
  * for preview + volume), tighten this back toward
  * `min(0.3 × siliconeThickness, 1 mm)` per the skill default.
  *
+ * Issue #76 — adaptive edgeLength for large masters
+ * -------------------------------------------------
+ *
+ * Pre-#76 the floor was a static `max(2.0, siliconeThickness/4)`. On
+ * masters with large bboxes (the user's "Testing Mold .stl" dogfood,
+ * bbox ~100×80×160 mm, ~1.28M mm³) the BCC sample count at edgeLength=
+ * 2.0 mm scaled ~30× vs the mini-figurine — observed ~53 s generate
+ * where mini-figurine is ~7 s.
+ *
+ * Fix: add a THIRD floor term derived from the master's raw bbox
+ * volume. At 150_000 mm³ target volume, the adaptive floor is
+ * `cbrt(bboxVol / 150_000)`. The overall edgeLength is the MAX of
+ * three floors:
+ *
+ *   1. Static 2.0 mm (preview-fidelity floor, issue #71).
+ *   2. Wall-thickness-proportional `siliconeThickness / 4` (skill
+ *      default for thin-wall masters).
+ *   3. Adaptive `cbrt(bboxVol / 150_000)` (this fix).
+ *
+ * Example calculations (raw master bbox volume):
+ *
+ *   - Mini-figurine (~50×70×40 mm, bboxVol≈140k mm³):
+ *       adaptive = cbrt(0.93) ≈ 0.98 → floor stays at 2.0 mm
+ *       (static wins). Mini-figurine CI perf unchanged — a hard
+ *       requirement of #76's AC "mini-figurine CI stays <5 s".
+ *   - Testing-mold (~100×80×160 mm, bboxVol≈1.28M mm³):
+ *       adaptive = cbrt(8.53) ≈ 2.04 → floor=2.04 mm. Sample count
+ *       drops ~1 % vs 2.0 mm — gentle smoothing.
+ *   - Large master (200×200×200 mm, bboxVol=8M mm³):
+ *       adaptive = cbrt(53.3) ≈ 3.77 → floor=3.77 mm. Sample count
+ *       drops ~7× vs 2.0 mm — the ~30-50 s generate on such masters
+ *       falls toward the #76 AC "<20 s locally".
+ *
+ * The cbrt floor is ≈ 1/edge of the grid in the direction of each
+ * axis: if we wanted a fixed TOTAL sample count `N` regardless of bbox
+ * size, we'd solve `edgeLength³ × N = bboxVol` → `edgeLength =
+ * cbrt(bboxVol / N)`. 150k ≈ "the sample count that makes a cube the
+ * size of a mini-figurine run at 2 mm edgeLength" — so below that
+ * threshold the adaptive floor is dormant and the static 2 mm
+ * controls, above it the adaptive floor picks up linearly in cube-root
+ * of bbox volume.
+ *
+ * Fidelity risk: at 3.77 mm edgeLength on a 200 mm master, the
+ * silicone outer is sampled at roughly `200 / 3.77 ≈ 53` cells per
+ * axis — marching-tetrahedra on a `siliconeThickness = 5 mm` offset
+ * (~1.3 grid cells deep) will produce a noticeably coarser iso-surface
+ * than the mini-figurine gets. For v1 this is acceptable: the
+ * silicone is a PREVIEW/volume body, not a printable artefact. When a
+ * future wave ships printable silicone, tighten the target volume
+ * (raise N) so the floor stays below `siliconeThickness / 3` even on
+ * large masters.
+ *
  * Thanks to the QA follow-up on PR #70 + issue #71 for surfacing the
- * pre-Wave-B perf regression.
+ * pre-Wave-B perf regression, and to the dogfood on "Testing Mold
+ * .stl" for surfacing the large-master perf cliff (#76).
+ *
+ * @param siliconeThickness_mm Silicone layer thickness in mm.
+ * @param masterBbox Axis-aligned bounding box of the TRANSFORMED
+ *   master (post-viewTransform). Used to derive the adaptive floor.
  */
-function resolveEdgeLength(siliconeThickness_mm: number): number {
-  return Math.max(2.0, siliconeThickness_mm / 4);
+export function resolveEdgeLength(
+  siliconeThickness_mm: number,
+  masterBbox: Box,
+): number {
+  const dx = masterBbox.max[0] - masterBbox.min[0];
+  const dy = masterBbox.max[1] - masterBbox.min[1];
+  const dz = masterBbox.max[2] - masterBbox.min[2];
+  const bboxVol = Math.max(0, dx) * Math.max(0, dy) * Math.max(0, dz);
+  const adaptiveFloor = Math.cbrt(
+    bboxVol / ADAPTIVE_EDGELENGTH_TARGET_BBOX_VOL_MM3,
+  );
+  return Math.max(2.0, siliconeThickness_mm / 4, adaptiveFloor);
 }
 
 /**
@@ -638,7 +717,13 @@ export async function generateSiliconeShell(
   try {
     assertManifold(transformedMaster, 'transformed master');
 
-    const edgeLength = resolveEdgeLength(parameters.siliconeThickness_mm);
+    // Compute the transformed-master bbox up front so `resolveEdgeLength`
+    // can consult it for the adaptive floor (issue #76).
+    const masterBbox = transformedMaster.boundingBox();
+    const edgeLength = resolveEdgeLength(
+      parameters.siliconeThickness_mm,
+      masterBbox,
+    );
     const siliconeThickness = parameters.siliconeThickness_mm;
     const shellThickness = parameters.printShellThickness_mm;
     const totalOffset = siliconeThickness + shellThickness;
@@ -692,8 +777,6 @@ export async function generateSiliconeShell(
     );
     const tSdf = performance.now();
     try {
-      const masterBbox = transformedMaster.boundingBox();
-
       // Issue #74 perf fix: unify the two levelSet bounds onto one grid.
       //
       // manifold-3d's `levelSet` derives its BCC sample lattice from

--- a/tests/geometry/generateMold.test.ts
+++ b/tests/geometry/generateMold.test.ts
@@ -37,6 +37,7 @@ import {
   manifoldToBufferGeometry,
 } from '@/geometry';
 import type { MoldGenerationResult } from '@/geometry/generateMold';
+import { resolveEdgeLength } from '@/geometry/generateMold';
 import { DEFAULT_PARAMETERS, type MoldParameters } from '@/renderer/state/parameters';
 import { fixtureExists, fixturePaths } from '@fixtures/meshes/loader';
 import { readFileSync } from 'node:fs';
@@ -1047,6 +1048,142 @@ describe('generateSiliconeShell — resinVolume tracks viewTransform (issue #81)
       master.delete();
     }
   }, 30_000);
+});
+
+describe('resolveEdgeLength — adaptive floor for large masters (issue #76)', () => {
+  // Pure-function coverage: `resolveEdgeLength` takes a silicone
+  // thickness and a manifold-3d `Box` (min/max 3-tuples) and returns
+  // the edgeLength to feed `Manifold.levelSet`. The adaptive floor is
+  // `cbrt(bboxVol / ADAPTIVE_EDGELENGTH_TARGET_BBOX_VOL_MM3)`
+  // (150_000 mm³ target). Max of three floors: 2.0 static,
+  // siliconeThickness/4, and the adaptive floor.
+  //
+  // These tests pin the example calculations documented in the
+  // `resolveEdgeLength` docstring — if someone tweaks the target
+  // volume, these assertions must be re-derived.
+  test('mini-figurine-sized bbox (~50×70×40 mm) stays at the 2.0 mm static floor', () => {
+    // bboxVol = 140_000; adaptive ≈ cbrt(0.93) ≈ 0.98 → static wins.
+    const bbox = {
+      min: [0, 0, 0] as [number, number, number],
+      max: [50, 70, 40] as [number, number, number],
+    };
+    const el = resolveEdgeLength(5, bbox);
+    expect(el).toBeCloseTo(2.0, 6);
+  });
+
+  test('testing-mold-sized bbox (~100×80×160 mm) gently raises past 2.0 mm', () => {
+    // bboxVol = 1.28M; adaptive ≈ cbrt(8.53) ≈ 2.04.
+    const bbox = {
+      min: [0, 0, 0] as [number, number, number],
+      max: [100, 80, 160] as [number, number, number],
+    };
+    const el = resolveEdgeLength(5, bbox);
+    // Adaptive floor should win — expect > 2.0 mm but under 3.0 mm.
+    expect(el).toBeGreaterThan(2.0);
+    expect(el).toBeLessThan(3.0);
+    // Explicit cbrt value to ±1 %.
+    expect(el).toBeCloseTo(Math.cbrt((100 * 80 * 160) / 150_000), 4);
+  });
+
+  test('large 200×200×200 mm bbox reaches edgeLength >= 3.0 mm', () => {
+    // bboxVol = 8M; adaptive ≈ cbrt(53.3) ≈ 3.77.
+    const bbox = {
+      min: [-100, -100, -100] as [number, number, number],
+      max: [100, 100, 100] as [number, number, number],
+    };
+    const el = resolveEdgeLength(5, bbox);
+    expect(el).toBeGreaterThanOrEqual(3.0);
+    expect(el).toBeCloseTo(Math.cbrt((200 * 200 * 200) / 150_000), 4);
+  });
+
+  test('thick-wall master: siliconeThickness/4 floor wins when adaptive is low', () => {
+    // Silicone thickness = 20 mm → static thin-wall floor = 20/4 = 5 mm.
+    // Small bbox (10×10×10 = 1000 mm³) → adaptive = cbrt(1000/150_000)
+    // ≈ 0.187 mm (dormant). Static 2.0 and silicone/4 = 5 compete;
+    // silicone/4 wins.
+    const bbox = {
+      min: [0, 0, 0] as [number, number, number],
+      max: [10, 10, 10] as [number, number, number],
+    };
+    const el = resolveEdgeLength(20, bbox);
+    expect(el).toBeCloseTo(5.0, 6);
+  });
+
+  test('degenerate (zero-volume) bbox falls back to the static 2.0 floor', () => {
+    // Empty-bbox path: min == max → bboxVol = 0. Adaptive floor =
+    // cbrt(0) = 0. Static 2.0 wins.
+    const bbox = {
+      min: [1, 2, 3] as [number, number, number],
+      max: [1, 2, 3] as [number, number, number],
+    };
+    const el = resolveEdgeLength(5, bbox);
+    expect(el).toBeCloseTo(2.0, 6);
+  });
+
+  test('scaled-unit-cube pipeline: 50× scaled master hits adaptive floor and still finishes', async () => {
+    // Integration test: a 50×50×50 mm cube (unit cube × 50 scale) has
+    // bboxVol = 125_000 mm³ raw (pre-transform); post 50×50×50 scale
+    // it's 125_000 mm³. Adaptive ≈ cbrt(125k/150k) ≈ 0.94 → static
+    // wins. Scale to 100×100×100 (via separate cube dim) to push
+    // adaptive past 2.0.
+    //
+    // We build a 200×200×200 mm cube via `Manifold.cube` so it sits
+    // at the "large master" target: edgeLength should climb to ~3.77
+    // and the generate pipeline should still produce a watertight
+    // silicone + shell without blowing the 12 s budget.
+    const toplevel = await initManifold();
+    const bigCube = toplevel.Manifold.cube([200, 200, 200], true);
+    try {
+      // Pre-check via the pure function — adaptive floor dominates here.
+      const bboxForCheck = bigCube.boundingBox();
+      const el = resolveEdgeLength(5, bboxForCheck);
+      expect(el).toBeGreaterThanOrEqual(3.0);
+
+      const t0 = performance.now();
+      const result = await generateSiliconeShell(
+        bigCube,
+        params({ siliconeThickness_mm: 5, printShellThickness_mm: 8 }),
+        new Matrix4(),
+      );
+      const elapsed = performance.now() - t0;
+      try {
+        // Pipeline completes and produces manifold outputs.
+        expect(isManifold(result.silicone)).toBe(true);
+        expect(result.silicone.isEmpty()).toBe(false);
+        expect(result.shellPieces.length).toBe(DEFAULT_PARAMETERS.sideCount);
+        for (const piece of result.shellPieces) {
+          expect(isManifold(piece)).toBe(true);
+          expect(piece.isEmpty()).toBe(false);
+        }
+
+        // Resin identity still holds with the coarser grid.
+        const masterVol = bigCube.volume();
+        expect(result.resinVolume_mm3).toBeCloseTo(masterVol, 6);
+
+        // Perf budget: 200³ cube at edgeLength 3.77 has roughly the
+        // same sample count as the mini-figurine at 2.0 mm (both hit
+        // ~150k target). Pipeline should stay comfortably under the
+        // mini-figurine budget (12 s) — the whole point of the
+        // adaptive floor.
+        //
+        // Skipped under coverage instrumentation (coverage slows the
+        // closure-heavy SDF loop ~7×).
+        const worker = (
+          globalThis as {
+            __vitest_worker__?: { config?: { coverage?: { enabled?: boolean } } };
+          }
+        ).__vitest_worker__;
+        const coverageEnabled = !!worker?.config?.coverage?.enabled;
+        if (!coverageEnabled) {
+          expect(elapsed).toBeLessThan(12_000);
+        }
+      } finally {
+        disposeAll(result);
+      }
+    } finally {
+      bigCube.delete();
+    }
+  }, 60_000);
 });
 
 describe('generateSiliconeShell — Generate×3 leak check', () => {


### PR DESCRIPTION
## Summary

Two bundled perf improvements on the geometry pipeline:

- **#76** — adaptive `edgeLength` floor for large masters. Adds a third floor term `cbrt(bboxVol / 150_000)` to `resolveEdgeLength` so 200+ mm masters scale the levelSet grid down proportionally. Mini-figurine unchanged (stays at 2.0 mm); large masters get ~7× sample-count reduction.
- **#86** — Wave E+F brim claw-back. Batches the per-piece brim pipeline from 4 boolean ops (2 diff + 2 union) to 3 (merge + diff + union), so the expensive `siliconeOuter` subtract runs once per piece instead of per brim.

Closes #76.
Closes #86.

## Formula chosen for #76

Third floor term added to `resolveEdgeLength`:

```ts
const bboxVol = dx * dy * dz;
const adaptiveFloor = Math.cbrt(bboxVol / ADAPTIVE_EDGELENGTH_TARGET_BBOX_VOL_MM3);
// ADAPTIVE_EDGELENGTH_TARGET_BBOX_VOL_MM3 = 150_000
return Math.max(2.0, siliconeThickness_mm / 4, adaptiveFloor);
```

Example calculations (from the docstring):

| Master | bboxVol | Adaptive | Final edgeLength |
|---|---|---|---|
| Mini-figurine (~50×70×40) | ~140k mm³ | cbrt(0.93) ≈ 0.98 | **2.0** (static wins) |
| Testing-mold (~100×80×160) | ~1.28M mm³ | cbrt(8.53) ≈ 2.04 | **2.04** (adaptive wins) |
| Large 200×200×200 | 8M mm³ | cbrt(53.3) ≈ 3.77 | **3.77** (adaptive wins) |

Target volume 150k picked so mini-figurine stays at the static 2.0 mm floor (issue #76 AC "mini-figurine CI stays <5 s") while a 200³ master lands at ≥ 3.0 mm (agent's-call requirement).

## Levers applied for #86

- **Lever 1 (drop `siliconeOuter` subtract): verified UNSAFE.** Ring-fixture unit test has `brim ∩ siliconeOuter < 1 mm³`; on that fixture, `brim_inner = outerRadius − bondOverlap = 10 − 6 = 4 mm` sits INSIDE the 5 mm cavity radius. The subtract removes hundreds of mm³ of intrusion; dropping it fails the assertion. Documented in the new brim.ts comment.
- **Lever 2 (batch unions): applied.** Per-piece logic now:
  1. Build every brim prism for the piece.
  2. `Manifold.union(brimPrisms)` — cheap merge (prisms only graze near junction).
  3. Single `Manifold.difference([merged, siliconeOuter])` — expensive cavity subtract runs ONCE per piece.
  4. Single `Manifold.union(piece, carved)` — integrate.

  Boolean count per piece: **3 (was 4)**, with the expensive diff collapsed from N to 1. Cavity-safety invariant preserved via the distributive law of set-difference over union.

- **Lever 3 (parallelize pieces): deferred to #77** per prompt guidance.

## Measured perf — mini-figurine (local, warm WASM, avg of 3 runs)

| Metric | Baseline | Post-fix | Delta |
|---|---|---|---|
| `shell-brims` (ms) | 680 | 662 | **−18 ms (−2.6%)** |
| `total` (ms) | 6753 | 6720 | **−33 ms (−0.5%)** |

Local gain is modest because the silicone-levelset pass (≈ 4.1 s) dominates and is unaffected by either change. On ubuntu CI (~1.4× slower on geometry ops), the brim-phase claw-back projects to ~25-45 ms — small compared to the 12 s budget but directionally the correct side.

200³ cube integration test (new): **5.1 s total** at edgeLength=3.76 mm — easily under the 12 s budget and proves the adaptive floor works end-to-end. Pre-fix the same master would have run at edgeLength=2.0 mm with ~6× the sample count (projected ~30-50 s).

Perf budget kept at 12 s (not tightened to 9 s) because:
- Local gain is smaller than the prompt's trigger threshold ("drops from ~10s → under 8s").
- Observed ubuntu CI peak was 11.0 s pre-fix (per #94 history) — a 9 s budget would flake on CI noise.

## Test plan

- [x] `pnpm typecheck` green.
- [x] `pnpm lint` green.
- [x] `pnpm test` — 534 unit tests passing, 1 skipped (no regressions).
- [x] `pnpm test:e2e` — 23 Electron e2e tests passing.
- [x] New `resolveEdgeLength` suite (5 pure + 1 integration) passing.
- [x] Existing brim tests passing — watertight, genus 0, cavity-safe, disjoint-pieces.
- [x] `.github/workflows/` = `ci.yml` only at HEAD.

## Files touched

- `src/geometry/generateMold.ts` — adaptive floor in `resolveEdgeLength`; exported the pure function for direct test coverage; `masterBbox` lifted above the SDF closure so it's available for the floor calc.
- `src/geometry/brim.ts` — batched diff + union per piece.
- `tests/geometry/generateMold.test.ts` — new `resolveEdgeLength` suite with 5 unit + 1 integration tests.